### PR TITLE
ONNX: undefined behaviour fixes in ONNX importer

### DIFF
--- a/src/importer/onnx/ops/constant.cpp
+++ b/src/importer/onnx/ops/constant.cpp
@@ -37,9 +37,9 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
     const auto &output { node.output()[0] };
 
     hlir::constant* op { };
-    if (const auto value { get_attribute<const TensorProto*>(node, "value") })
+    if (const auto value { get_attribute<TensorProto>(node, "value") })
     {
-        auto&& v { *value.value() };
+        const auto& v { value.value() };
         shape_t shape { get_shape(v) };
         const auto value_dt { get_datatype(v) };
 
@@ -58,8 +58,7 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
         case TensorProto_DataType_FLOAT:
         {
             const auto& data { to<xt::xarray<float>>(v) };
-            xtl::span<const uint8_t> vec { reinterpret_cast<const uint8_t*>(data.data()), data.size() * sizeof(float) };
-            op = graph_.emplace<constant>(value_dt.value(), move(shape), vec);
+            op = graph_.emplace<constant>(value_dt.value(), move(shape), span_from(data));
             break;
         }
 
@@ -74,8 +73,7 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
             }
 
             const auto& data { convert_to<xt::xarray<float>>(v) };
-            xtl::span<const uint8_t> vec { reinterpret_cast<const uint8_t*>(data.data()), data.size() * sizeof(float) };
-            op = graph_.emplace<constant>(dt_float32, move(shape), vec);
+            op = graph_.emplace<constant>(dt_float32, move(shape), span_from(data));
             break;
         }
 
@@ -91,19 +89,18 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
     {
         op = graph_.emplace<constant>(static_cast<uint8_t>(value.value()));
     }
-    else if (const auto value { get_attribute<xtl::span<const std::int64_t>>(node, "value_ints") })
+    else if (const auto value { get_attribute<vector<int>>(node, "value_ints") })
     {
         auto&& v { value.value() };
         vector<uint8_t>&& vec { begin(v), end(v) };
         shape_t shape { 1, v.size() };
         op = graph_.emplace<constant>(dt_uint8, move(shape), vec);
     }
-    else if (const auto value { get_attribute<xtl::span<const float>>(node, "value_floats") })
+    else if (const auto value { get_attribute<vector<float>>(node, "value_floats") })
     {
         auto&& v { value.value() };
         shape_t shape { 1, v.size() };
-        xtl::span<const uint8_t> vec { reinterpret_cast<const uint8_t*>(v.data()), v.size() * sizeof(float) };
-        op = graph_.emplace<constant>(dt_float32, move(shape), vec);
+        op = graph_.emplace<constant>(dt_float32, move(shape), span_from(v));
     }
     else
     {

--- a/src/importer/onnx/ops/pad.cpp
+++ b/src/importer/onnx/ops/pad.cpp
@@ -56,11 +56,11 @@ void onnx_importer::convert_op_Pad(const NodeProto& node)
     if (!use_opset_version_9)
     {
         const auto &pads { node.input()[1] };
-        const auto* pads_initializer { get_initializer(pads) };
+        const auto &pads_initializer { get_initializer(pads) };
 
         if (pads_initializer)
         {
-            padding_value = to<axis_t>(*pads_initializer);
+            padding_value = to<axis_t>(pads_initializer.value());
         }
         else
         {
@@ -95,14 +95,14 @@ void onnx_importer::convert_op_Pad(const NodeProto& node)
         {
             const auto &constant_value { node.input()[2] };
 
-            const auto* constant_initializer { get_initializer(constant_value) };
+            const auto &constant_initializer { get_initializer(constant_value) };
             switch (input_type)
             {
             case dt_float32:
             {
                 if (constant_initializer)
                 {
-                    constant = to<float>(*constant_initializer);
+                    constant = to<float>(constant_initializer.value());
                 }
                 else
                 {
@@ -111,7 +111,7 @@ void onnx_importer::convert_op_Pad(const NodeProto& node)
 
                     if (data && data.value().size())
                     {
-                        constant = float(data.value()[0]);
+                        constant = data.value()[0];
                     }
                 }
                 break;
@@ -130,7 +130,7 @@ void onnx_importer::convert_op_Pad(const NodeProto& node)
 
                     if (data && data.value().size())
                     {
-                        constant = uint8_t(data.value()[0]);
+                        constant = data.value()[0];
                     }
                 }
                 break;

--- a/src/importer/onnx/ops/pool.cpp
+++ b/src/importer/onnx/ops/pool.cpp
@@ -77,11 +77,11 @@ void onnx_importer::convert_pool(const NodeProto& node, const reduce_op_t reduce
 
     array<size_t, 2> dilations { 1, 1 };
 
-    const auto &kernel_shape { get_attribute<xtl::span<const int64_t>>(node, "kernel_shape").value() };
+    const auto &kernel_shape { get_attribute<vector<int>>(node, "kernel_shape").value() };
 
     array<size_t, 2> strides { 1, 1 };
 
-    const auto &strides_attr { get_attribute<xtl::span<const int64_t>>(node, "strides") };
+    const auto &strides_attr { get_attribute<vector<int>>(node, "strides") };
     if (strides_attr)
     {
         const auto &strides_values { strides_attr.value() };

--- a/src/importer/onnx/ops/reshape.cpp
+++ b/src/importer/onnx/ops/reshape.cpp
@@ -37,13 +37,13 @@ void onnx_importer::convert_op_Reshape(const NodeProto& node)
     const auto input_type { get_datatype(input).value() };
     const auto &input_shape { get_shape(input) };
 
-    const auto* new_shape_initializer { get_initializer(shape) };
+    const auto &new_shape_initializer { get_initializer(shape) };
 
     axis_t new_shape;
 
     if (new_shape_initializer)
     {
-        new_shape = to<axis_t>(*new_shape_initializer);
+        new_shape = to<axis_t>(new_shape_initializer.value());
     }
     else
     {

--- a/src/importer/onnx/ops/resize.cpp
+++ b/src/importer/onnx/ops/resize.cpp
@@ -60,11 +60,11 @@ void onnx_importer::convert_op_Resize(const NodeProto& node)
     if (!use_version_9 && node.input().size() == 4)
     {
         const auto &size { node.input()[3] };
-        const auto* new_size_initializer { get_initializer(size) };
+        const auto &new_size_initializer { get_initializer(size) };
 
         if (new_size_initializer)
         {
-            new_size = to<axis_t>(*new_size_initializer);
+            new_size = to<axis_t>(new_size_initializer.value());
         }
         else
         {

--- a/src/importer/onnx/ops/slice.cpp
+++ b/src/importer/onnx/ops/slice.cpp
@@ -46,8 +46,8 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
         const string& starts_input_name { node.input()[1] };
         const string& ends_input_name { node.input()[2] };
 
-        const auto* begins_initializer { get_initializer(starts_input_name) };
-        const auto* ends_initializer{ get_initializer(ends_input_name) };
+        const auto &begins_initializer { get_initializer(starts_input_name) };
+        const auto &ends_initializer{ get_initializer(ends_input_name) };
 
         if (!begins_initializer)
         {
@@ -62,7 +62,7 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
         }
         else
         {
-            begins = to<axis_t>(*begins_initializer);
+            begins = to<axis_t>(begins_initializer.value());
         }
 
         if (!ends_initializer)
@@ -78,7 +78,7 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
         }
         else
         {
-            ends = to<axis_t>(*ends_initializer);
+            ends = to<axis_t>(ends_initializer.value());
         }
     }
     else
@@ -100,8 +100,8 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
     {
         if (node.input().size() > 3)
         {
-            const string& axes_input_name { node.input()[3] };
-            const auto* axes_initializer{ get_initializer(axes_input_name) };
+            const string &axes_input_name { node.input()[3] };
+            const auto &axes_initializer{ get_initializer(axes_input_name) };
 
             if (!axes_initializer)
             {
@@ -114,7 +114,7 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
             }
             else
             {
-                loaded_axes = to<axis_t>(*axes_initializer);
+                loaded_axes = to<axis_t>(axes_initializer.value());
             }
         }
     }
@@ -128,9 +128,9 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
 
     if (node.input().size() > 4)
     {
-        const string& strides_input_name { node.input()[4] };
+        const string &strides_input_name { node.input()[4] };
 
-        const auto* strides_initializer{ get_initializer(strides_input_name) };
+        const auto &strides_initializer{ get_initializer(strides_input_name) };
 
         if (!strides_initializer)
         {
@@ -143,7 +143,7 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
         }
         else
         {
-            loaded_strides = to<axis_t>(*strides_initializer);
+            loaded_strides = to<axis_t>(strides_initializer.value());
         }
 
         assert(loaded_strides.size() == loaded_axes.size());


### PR DESCRIPTION
Following the discussion at #103 I've found and fixed several constructions with great UB potential in the Protobuf accessing methods. The initial code was too optimistic about using both the internal and provided structures of Protobuf objects without deep copy, still in most cases there were no lifetime guarantees, hence the subtle bugs were about to come. Now it's probably a little slower, but more stable, and as that's just importing of the model, not the inference, it's probably the right balance here. Could you please look it through and consider the merge?