### PR TITLE
Maybe bring back dot dump of the graph after importing

### DIFF
--- a/src/nncase/compiler.cpp
+++ b/src/nncase/compiler.cpp
@@ -136,6 +136,11 @@ public:
     input_layout_ = options.input_layout;
 
 #define END_IMPORT() \
+    if (compile_options_.dump_ir)                      \
+    {                                                  \
+        std::ofstream f(compile_options_.dump_dir / "ir_import.dot"); \
+        do_dump_graph(graph_, f);                      \
+    }                                                  \
     dump_graph(graph_, "import");
 
     void import_tflite(std::span<const uint8_t> model, const import_options &options) override


### PR DESCRIPTION
Started my experiments with the freshly refactored version of nncase and ONNX import in particular and found, that the DOT dump of the graph is now dropped with `--dump-ir` key is on, still the code of the output is still there and quite fine. Maybe I miss something, but here's a little edition to enable it again for the moment after the import phase.