### PR TITLE
Naming for the nodes during the import from ONNX

### DIFF
--- a/include/nncase/runtime/datatypes.h
+++ b/include/nncase/runtime/datatypes.h
@@ -136,6 +136,22 @@ typedef enum _reduce_op
     reduce_sum
 } reduce_op_t;
 
+inline std::string reduce_op_to_string(reduce_op_t op)
+{
+    switch (op)
+    {
+    case reduce_mean:
+        return "reduce_mean";
+    case reduce_min:
+        return "reduce_min";
+    case reduce_max:
+        return "reduce_max";
+    case reduce_sum:
+        return "reduce_sum";
+    }
+    return "unknown";
+}
+
 typedef enum _binary_op
 {
     binary_add,

--- a/src/importer/onnx/onnx_importer.cpp
+++ b/src/importer/onnx/onnx_importer.cpp
@@ -788,3 +788,11 @@ shape_t onnx_importer::broadcast_shape(const shape_t &v_shape, const shape_t &in
 
     return result;
 }
+
+std::string onnx_importer::generate_name(const onnx::NodeProto &node) const
+{
+    if (node.has_name())
+        return node.name();
+    else
+        return 'n' + std::to_string(graph_.nodes().size());
+}

--- a/src/importer/onnx/onnx_importer.h
+++ b/src/importer/onnx/onnx_importer.h
@@ -102,6 +102,7 @@ namespace nncase::importer
         static xtl::span<const std::uint8_t> span_from(const Cont &data);
 
         nncase::ir::shape_t broadcast_shape(const nncase::ir::shape_t &v_shape, const nncase::ir::shape_t &input_shape) noexcept;
+        std::string generate_name(const onnx::NodeProto &node) const;
 
         ir::graph &graph_;
         onnx::ModelProto model_;

--- a/src/importer/onnx/ops/binary.cpp
+++ b/src/importer/onnx/ops/binary.cpp
@@ -58,6 +58,8 @@ void onnx_importer::convert_binary(const onnx::NodeProto &node, const binary_op_
     assert(node.input().size() == 2);
     assert(node.output().size() == 1);
 
+    const auto &op_name { generate_name(node) };
+
     const auto &input_a = node.input()[0];
     const auto &input_b = node.input()[1];
     const auto &output = node.output()[0];
@@ -65,6 +67,7 @@ void onnx_importer::convert_binary(const onnx::NodeProto &node, const binary_op_
     auto input_a_shape = get_shape(input_a);
     auto input_b_shape = get_shape(input_b);
     auto op = graph_.emplace<binary>(binary_op, input_a_shape, input_b_shape, value_range<float>::full());
+    op->name(op_name + '(' + binary_op_to_string(binary_op) + ')');
 
     input_tensors_.emplace(&op->input_a(), input_a);
     input_tensors_.emplace(&op->input_b(), input_b);

--- a/src/importer/onnx/ops/clip.cpp
+++ b/src/importer/onnx/ops/clip.cpp
@@ -30,12 +30,15 @@ void onnx_importer::convert_op_Clip(const NodeProto &node)
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
+    const auto &op_name { generate_name(node) };
+
     constant *min_op = nullptr;
     std::string input_min;
     if (node.input().size() < 2)
     {
         const auto min_attr = get_attribute<float>(node, "min");
         min_op = graph_.emplace<constant>(min_attr ? min_attr.value() : std::numeric_limits<float>::lowest());
+        min_op->name(op_name + ".min(Clip)");
     }
     else
     {
@@ -48,6 +51,7 @@ void onnx_importer::convert_op_Clip(const NodeProto &node)
     {
         const auto max_attr = get_attribute<float>(node, "max");
         max_op = graph_.emplace<constant>(max_attr ? max_attr.value() : std::numeric_limits<float>::max());
+        max_op->name(op_name + ".max(Clip)");
     }
     else
     {
@@ -57,6 +61,8 @@ void onnx_importer::convert_op_Clip(const NodeProto &node)
     auto op = graph_.emplace<clamp>(get_shape(input),
         min_op ? min_op->output().shape() : get_shape(input_min),
         max_op ? max_op->output().shape() : get_shape(input_max));
+
+    op->name(op_name + ".clamp(Clip)");
 
     input_tensors_.emplace(&op->input(), input);
 

--- a/src/importer/onnx/ops/concat.cpp
+++ b/src/importer/onnx/ops/concat.cpp
@@ -45,6 +45,8 @@ size_t axis_count(const std::vector<shape_t> &shapes)
 
 void onnx_importer::convert_op_Concat(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     std::vector<shape_t> inputs_shapes;
     std::vector<datatype_t> inputs_types;
 
@@ -58,6 +60,7 @@ void onnx_importer::convert_op_Concat(const NodeProto &node)
     const size_t axis = real_axis(get_attribute<int64_t>(node, "axis").value(), axis_count(inputs_shapes));
 
     auto con = graph_.emplace<concat>(op_type, inputs_shapes, axis);
+    con->name(op_name + "(Concat)");
 
     for (int i = 0; i < node.input().size(); i++)
         input_tensors_.emplace(&con->input_at(i), node.input()[i]);

--- a/src/importer/onnx/ops/constant.cpp
+++ b/src/importer/onnx/ops/constant.cpp
@@ -86,6 +86,7 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
     else if (const auto value = get_attribute<float>(node, "value_float"))
     {
         op = graph_.emplace<constant>(value.value());
+        op->name(generate_name(node) + "(Constant)");
     }
     else if (const auto value = get_attribute<std::vector<float>>(node, "value_floats"))
     {
@@ -93,6 +94,7 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
         std::vector<float> vec { v.begin(), v.end() };
         shape_t shape { 1, v.size() };
         op = graph_.emplace<constant>(dt_float32, shape, vec);
+        op->name(generate_name(node) + "(Constant)");
     }
     else if (const auto value = get_attribute<int>(node, "value_int"))
     {
@@ -104,6 +106,7 @@ void onnx_importer::convert_op_Constant(const NodeProto &node)
         std::vector<uint8_t> vec { v.begin(), v.end() };
         shape_t shape { 1, v.size() };
         op = graph_.emplace<constant>(dt_uint8, shape, vec);
+        op->name(generate_name(node) + "(Constant)");
     }
     else
     {

--- a/src/importer/onnx/ops/conv.cpp
+++ b/src/importer/onnx/ops/conv.cpp
@@ -70,6 +70,8 @@ void onnx_importer::convert_op_ConvTranspose(const NodeProto &node)
 template <class Node>
 void onnx_importer::convert_conv(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &weight = node.input()[1];
     const auto &output = node.output()[0];
@@ -152,6 +154,7 @@ void onnx_importer::convert_conv(const NodeProto &node)
     }
 
     auto conv = add_conv_node<Node>(node, graph_, input_shape, weight_shape, group, pads, strides, dilations);
+    conv->name(op_name + "(Conv2d)");
 
     input_tensors_.emplace(&conv->input(), input);
     input_tensors_.emplace(&conv->weights(), weight);

--- a/src/importer/onnx/ops/dropout.cpp
+++ b/src/importer/onnx/ops/dropout.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Dropout(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -33,6 +35,7 @@ void onnx_importer::convert_op_Dropout(const NodeProto &node)
 
     // Depending on whether it is in test mode or not, the output Y will either be a random dropout, or a simple copy of the input
     auto bc = graph_.emplace<bitcast>(input_type, input_shape, input_shape);
+    bc->name(op_name + "(Dropout)");
     input_tensors_.emplace(&bc->input(), input);
     output_tensors_.emplace(output, &bc->output());
 }

--- a/src/importer/onnx/ops/flatten.cpp
+++ b/src/importer/onnx/ops/flatten.cpp
@@ -40,6 +40,8 @@ axis_t compose_new_shape(const shape_t &input_shape, const size_t flatten_axis)
 
 void onnx_importer::convert_op_Flatten(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -50,6 +52,7 @@ void onnx_importer::convert_op_Flatten(const NodeProto &node)
     const size_t flatten_axis = axis_attr ? real_axis(axis_attr.value(), input_shape.size()) : 1 ;
     const axis_t &new_shape = compose_new_shape(input_shape, flatten_axis);
     auto op = graph_.emplace<bitcast>(input_type, input_shape, new_shape);
+    op->name(op_name + "(Flatten)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/gemm.cpp
+++ b/src/importer/onnx/ops/gemm.cpp
@@ -28,6 +28,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Gemm(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     assert(node.input().size() >= 2 && node.input().size() <= 3);
     assert(node.output().size() > 0 && node.output().size() <= 5);
 
@@ -58,14 +60,22 @@ void onnx_importer::convert_op_Gemm(const NodeProto &node)
     };
 
     auto transA_op = transA ? add_transpose(input_A) : nullptr;
+    if (transA_op)
+        transA_op->name(op_name + ".transpose_A(Gemm)");
+
     auto transB_op = transB ? add_transpose(input_B) : nullptr;
+    if (transB_op)
+        transB_op->name(op_name + ".transpose_B(Gemm)");
 
     const auto &As_shape = transA ? transA_op->output().shape() : get_shape(input_A);
     const auto &Bs_shape = transB ? transB_op->output().shape() : get_shape(input_B);
 
     auto alpha = graph_.emplace<constant>(alpha_value);
+    alpha->name(op_name + ".alpha(Gemm)");
     auto alpha_A_op = graph_.emplace<binary>(binary_mul, alpha->output().shape(), As_shape, value_range<float>::full());
+    alpha_A_op->name(op_name + ".mul_A(Gemm)");
     auto A_B_op = graph_.emplace<matmul>(alpha_A_op->output().shape(), Bs_shape, value_range<float>::full());
+    A_B_op->name(op_name + ".matmul(Gemm)");
 
     alpha_A_op->input_a().connect(alpha->output());
     A_B_op->input_a().connect(alpha_A_op->output());
@@ -92,23 +102,26 @@ void onnx_importer::convert_op_Gemm(const NodeProto &node)
 
     if (node.input().size() > 2)
     {
-		const auto beta_attr = get_attribute<float>(node, "beta");
-		const float beta_value = beta_attr ? beta_attr.value() : 1.0f;
+        const auto beta_attr = get_attribute<float>(node, "beta");
+        const float beta_value = beta_attr ? beta_attr.value() : 1.0f;
         auto beta = graph_.emplace<constant>(beta_value);
-		const auto &input_C = node.input()[2];
+        beta->name(op_name + ".beta(Gemm)");
+        const auto &input_C = node.input()[2];
         auto beta_C_op = graph_.emplace<binary>(binary_mul, beta->output().shape(), get_shape(input_C), value_range<float>::full());
+        beta_C_op->name(op_name + ".mul_C(Gemm)");
 
         beta_C_op->input_a().connect(beta->output());
-		A_B_op->bias().connect(beta_C_op->output());
+        A_B_op->bias().connect(beta_C_op->output());
 
         input_tensors_.emplace(&beta_C_op->input_b(), input_C);
     }
     else
     {
-		std::vector<float> bias_value(As_shape.back(), 0.f);
-		shape_t bias_shape = { As_shape.back() };
-		auto bias = graph_.emplace<constant>(dt_float32, bias_shape, bias_value);
-		A_B_op->bias().connect(bias->output());
+        std::vector<float> bias_value(As_shape.back(), 0.f);
+        shape_t bias_shape = { As_shape.back() };
+        auto bias = graph_.emplace<constant>(dt_float32, bias_shape, bias_value);
+        bias->name(op_name + ".bias(Gemm)");
+        A_B_op->bias().connect(bias->output());
     }
-	output_tensors_.emplace(output, &A_B_op->output());
+    output_tensors_.emplace(output, &A_B_op->output());
 }

--- a/src/importer/onnx/ops/identity.cpp
+++ b/src/importer/onnx/ops/identity.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Identity(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -32,6 +34,7 @@ void onnx_importer::convert_op_Identity(const NodeProto &node)
     const auto &input_shape = get_shape(input);
 
     auto bc = graph_.emplace<bitcast>(input_type, input_shape, input_shape);
+    bc->name(op_name + ".broadcast(Identity)");
     input_tensors_.emplace(&bc->input(), input);
     output_tensors_.emplace(output, &bc->output());
 }

--- a/src/importer/onnx/ops/matmul.cpp
+++ b/src/importer/onnx/ops/matmul.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_MatMul(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input_a = node.input()[0];
     const auto &input_b = node.input()[1];
     const auto &output = node.output()[0];
@@ -35,8 +37,10 @@ void onnx_importer::convert_op_MatMul(const NodeProto &node)
     std::vector<float> bias_value(input_b_shape.back(), 0.f);
     shape_t bias_shape = { input_b_shape.back() };
     auto bias = graph_.emplace<constant>(dt_float32, bias_shape, bias_value);
+    bias->name(op_name + ".bias(MatMul)");
 
     auto mmul = graph_.emplace<matmul>(std::move(input_a_shape), std::move(input_b_shape), value_range<float>::full());
+    mmul->name(op_name + ".matmul(MatMul)");
     mmul->bias().connect(bias->output());
 
     input_tensors_.emplace(&mmul->input_a(), input_a);

--- a/src/importer/onnx/ops/pad.cpp
+++ b/src/importer/onnx/ops/pad.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Pad(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -146,6 +148,7 @@ void onnx_importer::convert_op_Pad(const NodeProto &node)
         std::cout << "Warning: non-zero padding value specified, which is not supported by the hardware, it will be ignored" << std::endl;
 
     auto op = graph_.emplace<pad>(input_type, input_shape, new_paddings, mod, std::move(constant));
+    op->name(op_name + "(Pad)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/pool.cpp
+++ b/src/importer/onnx/ops/pool.cpp
@@ -68,6 +68,8 @@ void onnx_importer::convert_op_GlobalMaxPool(const NodeProto &node)
 template <bool global>
 void onnx_importer::convert_pool(const NodeProto &node, const reduce_op_t reduce_op, const float init_value)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -129,6 +131,8 @@ void onnx_importer::convert_pool(const NodeProto &node, const reduce_op_t reduce
 
     auto op = graph_.emplace<reduce_window2d>(reduce_op, move(input_shape), init_value, kernel_shape[0], kernel_shape[1],
                                               pads[0], pads[1], strides[0], strides[1], dilations[0], dilations[1], value_range<float>::full());
+
+    op->name(op_name + '.' + reduce_op_to_string(reduce_op)+ "(Pool)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/reduce.cpp
+++ b/src/importer/onnx/ops/reduce.cpp
@@ -47,6 +47,8 @@ void onnx_importer::convert_op_ReduceSum(const NodeProto &node)
 
 void onnx_importer::convert_reduce(const NodeProto &node, const reduce_op_t reduce_op, const float init_value)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -68,6 +70,7 @@ void onnx_importer::convert_reduce(const NodeProto &node, const reduce_op_t redu
         keepdims = static_cast<bool>(keepdims_attr.value());
 
     auto op = graph_.emplace<reduce>(reduce_op, input_shape, std::move(axes), init_value, keepdims);
+    op->name(op_name + '(' + reduce_op_to_string(reduce_op) + ')');
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/reshape.cpp
+++ b/src/importer/onnx/ops/reshape.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Reshape(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &shape = node.input()[1];
     const auto &output = node.output()[0];
@@ -82,6 +84,7 @@ void onnx_importer::convert_op_Reshape(const NodeProto &node)
     }
 
     auto op = graph_.emplace<bitcast>(input_type, input_shape, new_shape);
+    op->name(op_name + "(Reshape)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/resize.cpp
+++ b/src/importer/onnx/ops/resize.cpp
@@ -36,6 +36,8 @@ image_resize_mode_t parse_image_resize_mode(const std::string &value) noexcept
 
 void onnx_importer::convert_op_Resize(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const bool use_version_10 = (node.input().size() == 2) && (get_datatype(node.input()[1]).value() == dt_float32);
     const auto &scale = use_version_10 ? node.input()[1] : node.input()[2];
@@ -100,6 +102,7 @@ void onnx_importer::convert_op_Resize(const NodeProto &node)
     const std::array<int32_t, 2> new_size_array = { new_size[2], new_size[3] };
 
     auto op = graph_.emplace<resize_image>(input_type, mode, input_shape, new_size_array, align_corners, pytorch_half_pixel);
+    op->name(op_name + "(Resize)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/slice.cpp
+++ b/src/importer/onnx/ops/slice.cpp
@@ -26,6 +26,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Slice(const NodeProto& node)
 {
+    const auto &op_name { generate_name(node) };
+
     const std::string &data_input_name = node.input()[0];
     const datatype_t data_type = get_datatype(data_input_name).value();
     const shape_t &data_shape = get_shape(data_input_name);
@@ -161,6 +163,7 @@ void onnx_importer::convert_op_Slice(const NodeProto& node)
     ends = permuted_ends;
 
     auto sl = graph_.emplace<slice>(data_type, data_shape, begins, ends, strides, 0, 0, 0, 0);
+    sl->name(op_name + "(Slice)");
 
     input_tensors_.emplace(&sl->input(), data_input_name);
     output_tensors_.emplace(node.output()[0], &sl->output());

--- a/src/importer/onnx/ops/squeeze.cpp
+++ b/src/importer/onnx/ops/squeeze.cpp
@@ -41,6 +41,8 @@ axis_t single_dim_axes(const shape_t &shape)
 
 void onnx_importer::convert_op_Squeeze(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -80,6 +82,7 @@ void onnx_importer::convert_op_Squeeze(const NodeProto &node)
     }
 #endif
     auto op = graph_.emplace<bitcast>(input_type, input_shape, new_shape);
+    op->name(op_name + "(Squeeze)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/sum.cpp
+++ b/src/importer/onnx/ops/sum.cpp
@@ -26,6 +26,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Sum(const onnx::NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     assert(node.input().size() >= 1);
     assert(node.output().size() == 1);
 
@@ -42,6 +44,7 @@ void onnx_importer::convert_op_Sum(const onnx::NodeProto &node)
         auto input_b_shape = get_shape(input_b);
 
         auto cur_op = graph_.emplace<binary>(binary_add, input_a_shape, input_b_shape, value_range<float>::full());
+        cur_op->name(op_name + ".add(Sum)");
         if (last_op != nullptr)
         {
             cur_op->input_a().connect(last_op->output());
@@ -66,6 +69,7 @@ void onnx_importer::convert_op_Sum(const onnx::NodeProto &node)
         const datatype_t input_type = get_datatype(input).value();
         const auto &input_shape = get_shape(input);
         auto bc = graph_.emplace<bitcast>(input_type, input_shape, input_shape);
+        bc->name(op_name + ".broadcast(Sum)");
         input_tensors_.emplace(&bc->input(), input);
         output_tensors_.emplace(output, &bc->output());
     }

--- a/src/importer/onnx/ops/transpose.cpp
+++ b/src/importer/onnx/ops/transpose.cpp
@@ -27,6 +27,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Transpose(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -42,6 +44,7 @@ void onnx_importer::convert_op_Transpose(const NodeProto &node)
         perm = perm_attr.value();
 
     auto op = graph_.emplace<transpose>(input_type, input_shape, std::move(perm));
+    op->name(op_name + "(Transpose)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/unary.cpp
+++ b/src/importer/onnx/ops/unary.cpp
@@ -81,11 +81,14 @@ void onnx_importer::convert_unary(const onnx::NodeProto &node, const unary_op_t 
     assert(node.input().size() == 1);
     assert(node.output().size() == 1);
 
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
     const auto &input_shape = get_shape(input);
     auto op = graph_.emplace<unary>(unary_op, input_shape);
+    op->name(op_name + '(' + unary_op_to_string(unary_op) + ')');
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/unsqueeze.cpp
+++ b/src/importer/onnx/ops/unsqueeze.cpp
@@ -25,6 +25,8 @@ using namespace onnx;
 
 void onnx_importer::convert_op_Unsqueeze(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -62,6 +64,7 @@ void onnx_importer::convert_op_Unsqueeze(const NodeProto &node)
     }
 
     auto op = graph_.emplace<bitcast>(input_type, input_shape, new_shape);
+    op->name(op_name + "(Unsqueeze)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());

--- a/src/importer/onnx/ops/upsample.cpp
+++ b/src/importer/onnx/ops/upsample.cpp
@@ -36,6 +36,8 @@ image_resize_mode_t parse_image_resize_mode(const std::string &value) noexcept
 
 void onnx_importer::convert_op_Upsample(const NodeProto &node)
 {
+    const auto &op_name { generate_name(node) };
+
     const auto &input = node.input()[0];
     const auto &output = node.output()[0];
 
@@ -84,6 +86,7 @@ void onnx_importer::convert_op_Upsample(const NodeProto &node)
     new_size[0] = *it;
 
     auto op = graph_.emplace<resize_image>(input_type, mode, input_shape, new_size, align_corners);
+    op->name(op_name + "(Upsample)");
 
     input_tensors_.emplace(&op->input(), input);
     output_tensors_.emplace(output, &op->output());


### PR DESCRIPTION
Node names are set during the importing the graph from ONNX. The naming based on the optional (yet pretty much always there) [node names](https://github.com/onnx/onnx/blob/31f0fd6103e231664d1cfd3b25264f672f5de960/onnx/onnx.proto#L202) in the original graph or on the total number of nodes in the graph at the moment (to get unique name for each next node created).

The overall scheme is like this:

**`2[.3](1)`**

where
1. ONNX operation type (like `Gemm` or `Add`).
2. Extracted or generated node name (see above).
3. Micro-operation created during the formula implementation for certain complex ONNX operations (like in `BatchNormalization`, `Gemm` etc.), if applicable.

Example: `Relu_1.max(Relu)`.