### PR TITLE
onnx: fix `pad` input data type for `Pad` op

### DIFF
--- a/src/importer/onnx/ops/pad.cpp
+++ b/src/importer/onnx/ops/pad.cpp
@@ -87,7 +87,7 @@ void onnx_importer::convert_op_Pad(const NodeProto &node)
         else
         {
             // try to extract data from previous constant nodes
-            const auto data = get_constant_input_data<float>(pads);
+            const auto data = get_constant_input_data<int64_t>(pads);
             if (data)
                 std::transform(std::begin(data.value()), std::end(data.value()), std::back_inserter(paddings),
                     [](const auto e) { return static_cast<int>(e); });

--- a/tests/importer/onnx/basic/test_pad.py
+++ b/tests/importer/onnx/basic/test_pad.py
@@ -21,11 +21,12 @@ from onnx_test_runner import OnnxTestRunner
 import numpy as np
 
 
-def _make_module(in_shape, padding, constant_value, mode, op_version):
+def _make_module(in_shape, padding, constant_value, mode, op_version, value_format):
 
     input = helper.make_tensor_value_info('input', TensorProto.FLOAT, in_shape)
 
     initializers = None
+    nodes = []
 
     out_shape = in_shape.copy()
     out_shape[2] += padding[2] + padding[6]
@@ -76,7 +77,15 @@ def _make_module(in_shape, padding, constant_value, mode, op_version):
             dims=dims_list,
             vals=padding)
 
-        initializers.append(pads)
+        if value_format == 'initializer':
+            initializers.append(pads)
+        else:
+            pads_node = helper.make_node(
+                'Constant',
+                inputs=[],
+                outputs=['pads'],
+                value=pads)
+            nodes.append(pads_node)
 
         inputs = ['input', 'pads']
         if constant_value is not None:
@@ -97,8 +106,10 @@ def _make_module(in_shape, padding, constant_value, mode, op_version):
             outputs=['output'],
             mode=mode)
 
+    nodes.append(node)
+
     graph_def = helper.make_graph(
-        [node],
+        nodes,
         'test-model',
         [input],
         [output],
@@ -145,14 +156,20 @@ op_versions = [
     13
 ]
 
+value_formats = [
+    'initializer',
+    'node'
+]
+
 
 @pytest.mark.parametrize('in_shape', in_shapes)
 @pytest.mark.parametrize('padding', paddings)
 @pytest.mark.parametrize('constant_value', constant_values)
 @pytest.mark.parametrize('mode', modes)
 @pytest.mark.parametrize('op_version', op_versions)
-def test_pad(in_shape, padding, constant_value, mode, op_version, request):
-    model_def = _make_module(in_shape, padding, constant_value, mode, op_version)
+@pytest.mark.parametrize('value_format', value_formats)
+def test_pad(in_shape, padding, constant_value, mode, op_version, value_format, request):
+    model_def = _make_module(in_shape, padding, constant_value, mode, op_version, value_format)
 
     runner = OnnxTestRunner(request.node.name)
     model_file = runner.from_onnx_helper(model_def)


### PR DESCRIPTION
Its data type is `int64` as per documentation (https://github.com/onnx/onnx/blob/master/docs/Changelog.md#pad-13), rather than `float`, which currently leads to extraction failure and assertion failure during the import.