### PR TITLE
remove fold_pad_maxpool from nncase

### DIFF
--- a/src/targets/neutral_target.cpp
+++ b/src/targets/neutral_target.cpp
@@ -150,7 +150,7 @@ void neutral_target::fold_pad_conv_transform(ir::transforms::transform_pass &pas
     pass.emplace<fold_pad_pad_transform>();
     pass.emplace<fuse_pad_conv2d_transform>();
     pass.emplace<fold_nop_pad_transform>();
-    pass.emplace<pad_to_maxpool_transform>();
+    // pass.emplace<pad_to_maxpool_transform>();
 }
 
 void neutral_target::fold_dilated_conv_transform(ir::transforms::transform_pass &pass, [[maybe_unused]] bool add_constant_folding)


### PR DESCRIPTION
remove fold pad+maxpool from nncase since neutral target does not support count_include_pad=true