### PR TITLE
Add rvv optimization for unary. 

### DIFF
--- a/src/evaluator/ops/neutral/neutral_ops.cpp
+++ b/src/evaluator/ops/neutral/neutral_ops.cpp
@@ -566,23 +566,7 @@ void register_neutral_evaluators()
             unary([](auto a) { return -a; });
             break;
         case unary_round:
-            unary([](auto a) {
-#if 0
-                return round(a);
-#else
-                        // bankers rounding method for tensorflow/tflite
-                        auto floor_val = std::floor(a);
-                        auto diff = a - floor_val;
-                        if ((diff < 0.5f) || ((diff == 0.5f) && (static_cast<int>(floor_val) % 2 == 0)))
-                        {
-                            return floor_val;
-                        }
-                        else
-                        {
-                            return floor_val = floor_val + 1.0f;
-                        }
-#endif
-            });
+            unary([](auto a) { return rintf(a); });
             break;
         case unary_rsqrt:
             unary([](auto a) { return 1.f / sqrtf(a); });

--- a/src/kernels/cpu/reference/unary.cpp
+++ b/src/kernels/cpu/reference/unary.cpp
@@ -55,7 +55,7 @@ result<void> reference::unary(unary_op_t op, const float *input, float *output, 
         UNARY_IMPL(unary_log, logf);
         UNARY_IMPL(unary_logical_not, [](float v) { return !v; });
         UNARY_IMPL(unary_neg, std::negate<float>());
-        UNARY_IMPL(unary_round, roundf);
+        UNARY_IMPL(unary_round, rintf);
         UNARY_IMPL(unary_rsqrt, [](float v) { return 1.f / sqrtf(v); });
         UNARY_IMPL(unary_sign, [](float v) { return (0.f < v) - (v < 0.f); });
         UNARY_IMPL(unary_sin, sinf);


### PR DESCRIPTION
- [x] Fix round mode.For halfway, roundf() means half away from 0, rintf() means half to even(tf/onnx).