### PR TITLE
Fix model import when `graph.value_info` is empty

### DIFF
--- a/src/importer/onnx/ops/conv.cpp
+++ b/src/importer/onnx/ops/conv.cpp
@@ -195,6 +195,9 @@ void onnx_importer::convert_op_ConvTranspose(const NodeProto &node)
     auto weight_shape = get_shape(weight);
     auto weight_type = get_datatype(weight).value();
 
+    const auto maybe_output_type = get_datatype(output);
+    const auto deduced_output_shape = maybe_output_type.has_value() ? get_shape(output) : std::optional<shape_t> { };
+
     // group
     const auto &group_attr = get_attribute<int>(node, "group");
     size_t group = group_attr ? group_attr.value() : 1;
@@ -255,7 +258,7 @@ void onnx_importer::convert_op_ConvTranspose(const NodeProto &node)
     std::string pad_mode = auto_pad_attr ? auto_pad_attr.value() : "NOTSET";
 
     // output_shape
-    auto output_shape { generate_output_shape(input_shape, weight_shape, paddings, dilations, strides, output_paddings) };
+    auto output_shape { deduced_output_shape.value_or(generate_output_shape(input_shape, weight_shape, paddings, dilations, strides, output_paddings)) };
     const auto &output_shape_attr = get_attribute<std::vector<int>>(node, "output_shape");
     if (output_shape_attr)
     {


### PR DESCRIPTION
Unfortunately, #310 broke ONNX import for models with graphs which don't have inputs and outputs of the nodes mentioned in `value_info` field of the graph, which is [optional](https://github.com/onnx/onnx/blob/f81558d4b24e910cbd05990f09e4ae78b7452560/onnx/onnx.proto#L463) and not the case e.g. for default export function in recent versions of PyTorch. The problem is that now it tries to obtain shape and data type of the output when converting `Conv` and `ConvTranspose` op nodes, while this information may only be found in graph's `value_info`. When it's there, it's there, otherwise (which is normal as per ONNX spec as well) it may only be inferred during the convertion of the exact same node which tries to search for it. Little recursive thing.

For the `Conv` the fix is pretty straightforward: output shape is simply not used and is removed, while output data type is the same as input data type (and weights data type) again according to the corresponding [ONNX op spec](https://github.com/onnx/onnx/blob/main/docs/Operators.md#type-constraints-26), both in older versions and those ones from 11 onwards. It is used in some new code added in #549, hopefully it respects the specification and nothing is broken with this change.

For the `ConvTranspose` I have to bring back `generate_output_shape()` from #103 helper function to initialize output shape. Still I change it to follow the output shape calculation found in the [`conv2d` IR op constructor](https://github.com/kendryte/nncase/blob/4173d50266f560bca9859dd92b1c176f127b3392/src/ir/ops/conv2d.cpp#L28). Hope it's good enough default value. When `output_shape` attribute is found, output shape is overriden from its value. The rest calculations are preserved.

I'm pretty sure it's fine for simple `Conv`, but could you please double check that it works properly for `ConvTranspose` case? I see there used to be some output shape issues which was going to be solved in #310, hopefully they are remaining fixed :)