### PR TITLE
fix pytest when multiple inputs have different type

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -316,7 +316,7 @@ class TestRunner(metaclass=ABCMeta):
 
     def data_pre_process(self, data):
         data = copy.deepcopy(data)
-        if self.pre_process[3]['input_type'] == "float32":
+        if self.pre_process[0]['preprocess'] and self.pre_process[3]['input_type'] == "float32":
             data = np.asarray(data, dtype=np.float32)
         if self.pre_process[0]['preprocess'] and len(data.shape) == 4:
             if self.pre_process[-1]['input_layout'] == 'NCHW':


### PR DESCRIPTION
fix pytest when multiple inputs have different type