### PR TITLE
Feature/rebuild ir pytest path

### DIFF
--- a/src/Nncase.Evaluator/Math/Quantize.cs
+++ b/src/Nncase.Evaluator/Math/Quantize.cs
@@ -25,10 +25,7 @@ public class QuantizeEvaluator : IEvaluator<Quantize>, ITypeInferencer<Quantize>
         // only support qint8 in onnx
         if (input.DataType == OrtDataType.Float && target.TargetType == DataTypes.Int16)
         {
-            var result = input.ToArray<float>().Select(x => (short)((x / quantParam.Scale) + quantParam.ZeroPoint)).ToArray();
-            return Value.FromTensor(Tensor.From(
-                result,
-                input.Shape.ToInts()));
+            return OrtKI.Cast((input / quantParam.Scale) + (float)quantParam.ZeroPoint, (int)OrtDataType.Int16).ToValue();
         }
 
         return OrtKI.QuantizeLinear(input, quantParam.Scale, zeroPoint.ToOrtTensor(), 0).ToValue();

--- a/src/Nncase.Evaluator/Math/Quantize.cs
+++ b/src/Nncase.Evaluator/Math/Quantize.cs
@@ -21,6 +21,7 @@ public class QuantizeEvaluator : IEvaluator<Quantize>, ITypeInferencer<Quantize>
         var input = context.GetOrtArgumentValue(target, Quantize.Input);
         var quantParam = context.GetArgumentValueAsScalar<QuantParam>(target, Quantize.QuantParam);
         var zeroPoint = Tensor.FromScalar(quantParam.ZeroPoint).CastTo(target.TargetType);
+
         // only support qint8 in onnx
         if (input.DataType == OrtDataType.Float && target.TargetType == DataTypes.Int16)
         {
@@ -29,6 +30,7 @@ public class QuantizeEvaluator : IEvaluator<Quantize>, ITypeInferencer<Quantize>
                 result,
                 input.Shape.ToInts()));
         }
+
         return OrtKI.QuantizeLinear(input, quantParam.Scale, zeroPoint.ToOrtTensor(), 0).ToValue();
     }
 

--- a/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
+++ b/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
@@ -486,6 +486,7 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var scale = 0.05F;
 
         var input1 = OrtKISharp.Tensor.MakeTensor(input, new long[] { 2, 4 });
+
         // onnxruntime does not support quantize to i16, result of kernel is i8
         var expect = OrtKI.Cast(
             OrtKI.QuantizeLinear(input1, scale, zeroPoint, axis),
@@ -495,7 +496,7 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var input2 = Tensor.From(input, new[] { 2, 4 });
         var expr = IR.F.Math.Quantize(input2, quantParam, DataTypes.Int16);
         CompilerServices.InferenceType(expr);
-        Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor(););
+        Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor(); )
     }
 
     [Fact]

--- a/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
+++ b/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
@@ -470,11 +470,32 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var input1 = OrtKISharp.Tensor.MakeTensor(input, new long[] { 2, 4 });
         var expect = OrtKI.QuantizeLinear(input1, scale, zero_point, axis);
 
-        var quant_param = new QuantParam(zero_point, scale);
+        var quantParam = new QuantParam(zero_point, scale);
         var input2 = Tensor.From(input, new[] { 2, 4 });
-        var expr = IR.F.Math.Quantize(input2, quant_param, DataTypes.UInt8);
+        var expr = IR.F.Math.Quantize(input2, quantParam, DataTypes.UInt8);
         CompilerServices.InferenceType(expr);
         Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor());
+    }
+
+    [Fact]
+    public void TestInt16Quantize()
+    {
+        var input = new float[] { 1.0F, 1.2F, 1.4F, 1.5F, 1.6F, 1.8F, 1.9F, 2.0F };
+        var axis = 0;
+        sbyte zeroPoint = 62;
+        var scale = 0.05F;
+
+        var input1 = OrtKISharp.Tensor.MakeTensor(input, new long[] { 2, 4 });
+        // onnxruntime does not support quantize to i16, result of kernel is i8
+        var expect = OrtKI.Cast(
+            OrtKI.QuantizeLinear(input1, scale, zeroPoint, axis),
+            (int)DataTypes.Int16.ToOrtType());
+
+        var quantParam = new QuantParam(zeroPoint, scale);
+        var input2 = Tensor.From(input, new[] { 2, 4 });
+        var expr = IR.F.Math.Quantize(input2, quantParam, DataTypes.Int16);
+        CompilerServices.InferenceType(expr);
+        Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor(););
     }
 
     [Fact]

--- a/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
+++ b/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
@@ -486,6 +486,7 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var scale = 0.05F;
 
         var input1 = OrtKISharp.Tensor.MakeTensor(input, new long[] { 2, 4 });
+
         // onnxruntime does not support quantize to i16, result of kernel is i8
         var expect = OrtKI.Cast(
             OrtKI.QuantizeLinear(input1, scale, zeroPoint, axis),

--- a/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
+++ b/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
@@ -486,7 +486,6 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var scale = 0.05F;
 
         var input1 = OrtKISharp.Tensor.MakeTensor(input, new long[] { 2, 4 });
-
         // onnxruntime does not support quantize to i16, result of kernel is i8
         var expect = OrtKI.Cast(
             OrtKI.QuantizeLinear(input1, scale, zeroPoint, axis),
@@ -496,7 +495,7 @@ public class UnitTestEvaluatorMath : TestFixture.UnitTestFixtrue
         var input2 = Tensor.From(input, new[] { 2, 4 });
         var expr = IR.F.Math.Quantize(input2, quantParam, DataTypes.Int16);
         CompilerServices.InferenceType(expr);
-        Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor(); )
+        Assert.Equal(expect, expr.Evaluate().AsTensor().ToOrtTensor());
     }
 
     [Fact]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -572,7 +572,7 @@ class TestRunner(Evaluator, Inference, metaclass=ABCMeta):
                     path_list.append(
                         (os.path.join(case_dir, name, f'{name}_{n}_{i}.bin'),
                          os.path.join(case_dir, name, f'{name}_{n}_{i}.txt')))
-                    data.tofile(path_list[-1][0])z
+                    data.tofile(path_list[-1][0])
                     self.totxtfile(path_list[-1][1], data)
                 samples.append(data)
             i += 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -555,6 +555,7 @@ class TestRunner(Evaluator, Inference, metaclass=ABCMeta):
 
     def generate_data(self, cfg, case_dir: str, inputs: List[Dict], path_list: List[str], name: str, preprocess_opt):
         i = 0
+        os.mkdir(os.path.join(case_dir, name))
         for input in inputs:
             samples = []
             shape = copy.deepcopy(input['model_shape'])
@@ -569,9 +570,9 @@ class TestRunner(Evaluator, Inference, metaclass=ABCMeta):
                 data = DataFactory[cfg.name](shape, input['dtype'], n, cfg.batch_size, **cfg.kwargs)
                 if not test_utils.in_ci():
                     path_list.append(
-                        (os.path.join(case_dir, f'{name}_{n}_{i}.bin'),
-                         os.path.join(case_dir, f'{name}_{n}_{i}.txt')))
-                    data.tofile(path_list[-1][0])
+                        (os.path.join(case_dir, name, f'{name}_{n}_{i}.bin'),
+                         os.path.join(case_dir, name, f'{name}_{n}_{i}.txt')))
+                    data.tofile(path_list[-1][0])z
                     self.totxtfile(path_list[-1][1], data)
                 samples.append(data)
             i += 1


### PR DESCRIPTION
dump_range_data, calib_data and input are all in the root directory of the generated files, making it difficult to find specific files
old:
-root
-dump_range_data_xx
-dump_range_data_xx
-dump_range_data_xx

new:
-root
-dump_range_data
--dump_range_data_xx
-calib_data
--calib_data_xx
-input
--input_xx