### PR TITLE
Feature/rebuild ir egraph extract with marker

### DIFF
--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -72,19 +72,20 @@ public class Compiler
         {
             passManager.Add(new EGraphPass("1_NeutralOptimize")
             {
-          new Transform.Rules.Neutral.FoldConstCall(),
-          new Transform.Rules.Neutral.FoldNopTranspose(),
-          new Transform.Rules.Neutral.FoldTwoTransposes(),
-          new Transform.Rules.Neutral.CombineTransposeUnary(),
-          new Transform.Rules.Neutral.CombineTransposePad(),
-          new Transform.Rules.Neutral.CombineTransposeBinary(),
-          new Transform.Rules.Neutral.CombineTransposeConstBinary(),
-          new Transform.Rules.Neutral.CombineTransposeReduce(),
-          new Transform.Rules.Neutral.CombineTransposeActivations(),
-          new Transform.Rules.Neutral.CombinePadTranspose(),
-          new Transform.Rules.Neutral.FoldNopPad(),
-          new Transform.Rules.Neutral.FoldConv2DPads(),
-          new Transform.Rules.Neutral.FoldReduceWindow2DPads(),
+              new Transform.Rules.Neutral.FoldConstCall(),
+              new Transform.Rules.Neutral.FoldNopTranspose(),
+              new Transform.Rules.Neutral.FoldTwoTransposes(),
+              new Transform.Rules.Neutral.CombineTransposeUnary(),
+              new Transform.Rules.Neutral.CombineTransposePad(),
+              new Transform.Rules.Neutral.CombinePadTranspose(),
+              new Transform.Rules.Neutral.CombineTransposeBinary(),
+              new Transform.Rules.Neutral.CombineTransposeConstBinary(),
+              new Transform.Rules.Neutral.CombineTransposeReduce(),
+              new Transform.Rules.Neutral.CombineTransposeActivations(),
+              new Transform.Rules.Neutral.CombineActivationsTranspose(),
+              new Transform.Rules.Neutral.FoldNopPad(),
+              new Transform.Rules.Neutral.FoldConv2DPads(),
+              new Transform.Rules.Neutral.FoldReduceWindow2DPads(),
             });
         }
 

--- a/src/Nncase.EGraph/CostModel/EGraphCostPrinter.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostPrinter.cs
@@ -57,37 +57,59 @@ public partial class EGraphPrinter
         DotGraph.Edges.Clear();
 
         HashSet<EClass> eclassMemo = new();
+        HashSet<EClass> markerEclassMemo = new();
 
-        bool Dfs(EClass curclass, ENode? minCostEnode)
+        void Dfs(EClass curclass)
         {
-            if (eclassMemo.Contains(curclass) || _opMaps.ContainsKey(curclass) || minCostEnode is null)
+            var stack = new Stack<EClass>();
+            stack.Push(curclass);
+            while (stack.Any())
             {
-                return false;
-            }
-
-            var (minCostDotnode, table) = NodesMap[minCostEnode];
-            minCostDotnode.Color = Color.DeepSkyBlue;
-            foreach (var (child, i) in minCostEnode.Children.Select((c, i) => (c, i)))
-            {
-                var childEnode = child.Find().Nodes.MinBy(x => costModel[x]);
-                if (!Dfs(child.Find(), childEnode))
+                var parent = stack.Pop();
+                if (eclassMemo.Contains(parent) || _opMaps.ContainsKey(parent))
                 {
                     continue;
                 }
 
-                var (childDotNode, _) = NodesMap[childEnode!];
-                DotGraph.Edges.Add(childDotNode, minCostDotnode, edge =>
+                var minCostEnode = parent.Nodes.MinBy(x => costModel[x])!;
+                if (markerEclassMemo.Contains(parent)) // when this marker ecalss has been visited, skip it.
+                    minCostEnode = parent.Nodes.Where(n => n.Expr is not Marker).MinBy(x => costModel[x])!;
+                var (minCostDotnode, table) = NodesMap[minCostEnode];
+                minCostDotnode.Color = Color.DeepSkyBlue;
+                foreach (var (child, i) in minCostEnode.Children.Select((c, i) => (c, i)))
                 {
-                    edge.Head.Endpoint.Port = new DotEndpointPort($"P{i}");
-                    edge.Color = Color.SpringGreen;
-                });
+                    if (_opMaps.ContainsKey(child))
+                        continue;
+                    // note when marker child is it's self need select other node.
+                    if (minCostEnode.Expr is Marker && child == parent)
+                    {
+                        markerEclassMemo.Add(child);
+                        var otherminCostENode = child.Nodes.Where(n => n.Expr is not Marker).MinBy(x => costModel[x])!;
+                        var (childDotNode, _) = NodesMap[otherminCostENode];
+                        DotGraph.Edges.Add(childDotNode, minCostDotnode, edge =>
+                        {
+                            edge.Head.Endpoint.Port = new DotEndpointPort($"P{i}");
+                            edge.Color = Color.SpringGreen;
+                        });
+                    }
+                    else
+                    {
+                        var childEnode = child.Find().Nodes.MinBy(x => costModel[x])!;
+                        var (childDotNode, _) = NodesMap[childEnode];
+                        DotGraph.Edges.Add(childDotNode, minCostDotnode, edge =>
+                        {
+                            edge.Head.Endpoint.Port = new DotEndpointPort($"P{i}");
+                            edge.Color = Color.SpringGreen;
+                        });
+                    }
+                    stack.Push(child);
+                }
+                if (!markerEclassMemo.Contains(parent))
+                    eclassMemo.Add(parent);
             }
-
-            eclassMemo.Add(curclass);
-            return true;
         }
 
-        Dfs(entry.Find(), entry.Find().Nodes.MinBy(x => costModel[x]));
+        Dfs(entry.Find());
         return DotGraph;
     }
 }

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
@@ -25,11 +25,13 @@ public class UnitTestDataFlowRewriteFactory : TestFixture.UnitTestFixtrue
 {
     public static TheoryData<IRewriteCase> DataOne => new()
     {
-        new PadTransposeCase(),
+      new ActivationsTranspose(),
+      new ActivationsTranspose2(),
     };
 
     public static TheoryData<IRewriteCase> DataAll => new()
     {
+        new PadTransposeCase(),
         new TransposeLeakyRelu(),
         new Conv2DPadsCase(),
         new ReduceWindow2DPadsCase(),

--- a/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
@@ -15,11 +15,13 @@ public sealed class UnitTestEGraphRewriteFactory : TestFixture.UnitTestFixtrue
 {
     public static TheoryData<IRewriteCase> DataOne => new()
     {
-        new PadTransposeCaseEgraph(),
+        new RemoveMarkerCaseEgraph(),
     };
 
     public static TheoryData<IRewriteCase> DataAll => new()
     {
+        new ActivationsTranspose(),
+        new ActivationsTranspose2(),
         new PadTransposeCase(),
         new MobileNetV1TransposeCase(),
         new Conv2DPadsCase(),
@@ -35,6 +37,7 @@ public sealed class UnitTestEGraphRewriteFactory : TestFixture.UnitTestFixtrue
         new FoldNopTransposeCase2(),
         new FoldNopTransposeCase1(),
         new FoldTransposeCase(),
+        new PadTransposeCaseEgraph(),
     };
 
     [Theory]

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestCombineTranspose.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestCombineTranspose.cs
@@ -260,18 +260,6 @@ public class UnitTestCombineTranspose : TestFixture.UnitTestFixtrue
         Assert.True(TestFixture.Comparator.AllEqual(CompilerServices.Evaluate(rootPre), CompilerServices.Evaluate(rootPost)));
     }
 
-    [Fact]
-    public void TestCombineTransposeRelu()
-    {
-        var caseOptions = GetPassOptions();
-        var a = Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 3, 8, 8 });
-        var rootPre = Relu(Tensors.Transpose(a, new[] { 0, 3, 1, 2 }));
-        var rootPost = CompilerServices.Rewrite(rootPre, new[] { new CombineTransposeRelu() }, caseOptions);
-
-        Assert.NotEqual(rootPre, rootPost);
-        Assert.Equal(CompilerServices.Evaluate(rootPre), CompilerServices.Evaluate(rootPost));
-    }
-
     [Theory]
     [MemberData(nameof(TestCombineTransposePadPositiveData))]
     public void TestCombineTransposePadPositive(int[] inShape, int[] perm, int[,] paddings, PadMode padM, float padValue)

--- a/src/Nncase.Transform/Rules/Neutral/FoldConstant.cs
+++ b/src/Nncase.Transform/Rules/Neutral/FoldConstant.cs
@@ -37,9 +37,11 @@ public partial class FoldConstCall : RewriteRule<CallPattern>
         TypePattern = IsType(x => !(x is InvalidType)),
     };
 
-    private Const GetReplace(Call call)
+    private Const GetReplace(Call call, IReadOnlyList<Expr> const_args)
     {
-        return Const.FromValue(call.Evaluate());
+        // note for egraphs.
+        var new_call = call with { Parameters = new(const_args) };
+        return Const.FromValue(new_call.Evaluate());
     }
 }
 


### PR DESCRIPTION
1. So far, the union of markers has not been used in egraph.
2. We have to make makrer equivalent to his input so that the rule can be matched arbitrarily with or without marker
3. But if the union of marker is added, the minCostEnode will be marker, lead to incorrect extraction of best expression:
![截屏2023-01-05 20 58 57](https://user-images.githubusercontent.com/26156999/210920519-87352b81-5adf-4a63-9adf-37f2944842fe.png)
4. Therefore, the logic of extraction is modified, and the marker node is forcibly added:
![截屏2023-01-06 00 23 48](https://user-images.githubusercontent.com/26156999/210920743-19dbe558-da33-4355-bd03-821a650ff0be.png)
5. remove the CombineTransposeRelu but add the CombineActivationsTranspose rule.