### PR TITLE
Feature/fix reduce decimal error

### DIFF
--- a/src/targets/neutral_target.cpp
+++ b/src/targets/neutral_target.cpp
@@ -250,16 +250,6 @@ void neutral_target::register_target_dependent_passes([[maybe_unused]] const mod
 void neutral_target::register_quantize_annotation_passes([[maybe_unused]] const module_type_t &type, ir::transforms::pass_manager &pass_mgr)
 {
     {
-        transform_pass p("fuse_unary");
-        p.emplace<fuse_one_unary_transform>();
-        p.emplace<fuse_one_binary_transform>();
-        p.emplace<fuse_two_fused_unary_transform>();
-        p.emplace<fuse_one_fused_unary_with_binary_transform>();
-        p.emplace<fuse_two_fused_unary_with_binary_transform>();
-        pass_mgr.add_pass(std::move(p));
-    }
-
-    {
         transform_pass p("annotate_neutral_quantize");
         p.emplace<add_quant_checkpoints_transform>(std::in_place, ir::op_fused_unary, ir::op_bitcast, ir::op_dequantize, ir::op_binary, ir::op_output_node);
         pass_mgr.add_pass(std::move(p));

--- a/targets/cpu/cpu_target.cpp
+++ b/targets/cpu/cpu_target.cpp
@@ -15,7 +15,10 @@
 #include "cpu_target.h"
 #include <nncase/plugin_loader.h>
 #include <nncase/transforms/neutral/fold_constant.h>
+#include <nncase/transforms/neutral/fuse_unary.h>
+#include <nncase/transforms/neutral/fused_unary_to_lookup1d.h>
 #include <nncase/transforms/neutral/lstm_transform.h>
+#include <nncase/transforms/neutral/add_quant_checkpoints.h>
 #include <nncase/transforms/pass.h>
 
 #if defined(_MSC_VER)
@@ -44,6 +47,25 @@ void cpu_target::register_target_dependent_passes([[maybe_unused]] const module_
         transform_pass p("lstm_transform");
         p.emplace<fold_constant_transform>();
         p.emplace<lstm_transform>();
+        pass_mgr.add_pass(std::move(p));
+    }
+}
+
+void cpu_target::register_quantize_annotation_passes([[maybe_unused]] const module_type_t &type, ir::transforms::pass_manager &pass_mgr)
+{
+    {
+        transform_pass p("fuse_unary");
+        p.emplace<fuse_one_unary_transform>();
+        p.emplace<fuse_one_binary_transform>();
+        p.emplace<fuse_two_fused_unary_transform>();
+        p.emplace<fuse_one_fused_unary_with_binary_transform>();
+        p.emplace<fuse_two_fused_unary_with_binary_transform>();
+        pass_mgr.add_pass(std::move(p));
+    }
+
+    {
+        transform_pass p("annotate_neutral_quantize");
+        p.emplace<add_quant_checkpoints_transform>(std::in_place, ir::op_fused_unary, ir::op_bitcast, ir::op_dequantize, ir::op_binary, ir::op_output_node);
         pass_mgr.add_pass(std::move(p));
     }
 }

--- a/targets/cpu/cpu_target.cpp
+++ b/targets/cpu/cpu_target.cpp
@@ -14,11 +14,11 @@
  */
 #include "cpu_target.h"
 #include <nncase/plugin_loader.h>
+#include <nncase/transforms/neutral/add_quant_checkpoints.h>
 #include <nncase/transforms/neutral/fold_constant.h>
 #include <nncase/transforms/neutral/fuse_unary.h>
 #include <nncase/transforms/neutral/fused_unary_to_lookup1d.h>
 #include <nncase/transforms/neutral/lstm_transform.h>
-#include <nncase/transforms/neutral/add_quant_checkpoints.h>
 #include <nncase/transforms/pass.h>
 
 #if defined(_MSC_VER)

--- a/targets/cpu/cpu_target.h
+++ b/targets/cpu/cpu_target.h
@@ -23,5 +23,6 @@ public:
     using neutral_target::neutral_target;
 
     void register_target_dependent_passes(const module_type_t &type, ir::transforms::pass_manager &pass_mgr, bool use_ptq, bool split_w_to_act) override;
+    void register_quantize_annotation_passes(const module_type_t &type, ir::transforms::pass_manager &pass_mgr) override;
 };
 }

--- a/tests/importer/tflite_/model/test_mobilenetv1.py
+++ b/tests/importer/tflite_/model/test_mobilenetv1.py
@@ -40,20 +40,55 @@ alphas = [
 def test_mobilenetv1(in_shape, alpha, request):
     module = _make_module(in_shape, alpha)
     overwrite_cfg = """
-     judge:
-       specifics:
-         - matchs:
-             target: [cpu, k510]
-             ptq: true
-           threshold: 0.98
-         - matchs:
-             target: [k210]
-             ptq: true
-           threshold: 0.94
-         - matchs:
-             target: [k510]
-             ptq: false
-           threshold: 0.99
+    case: 
+      preprocess_opt:
+        - name: preprocess
+          values:
+            - true
+        - name: swapRB
+          values:
+            - false
+        - name: input_shape
+          values:
+            - [1,224,224,3]
+        - name: mean
+          values:
+            - [0.5,0.5,0.5]
+        - name: std
+          values:
+            - [0.5,0.5,0.5]
+        - name: input_range
+          values:
+            - [0,1]
+        - name: input_type
+          values:
+            - float32
+        - name: model_layout
+          values:
+            - NHWC
+        - name: input_layout
+          values:
+            - NHWC
+        - name: output_layout
+          values:
+            - NHWC
+        - name: letterbox_value
+          values:
+            - 0.
+    judge:
+      specifics:
+        - matchs:
+            target: [cpu, k510]
+            ptq: true
+          threshold: 0.97
+        - matchs:
+            target: [k210]
+            ptq: true
+          threshold: 0.94
+        - matchs:
+            target: [k510]
+            ptq: false
+          threshold: 0.99
      """
     runner = TfliteTestRunner(request.node.name, overwrite_configs=overwrite_cfg)
     model_file = runner.from_tensorflow(module)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -109,7 +109,7 @@ def generate_random(shape: List[int], dtype: np.dtype,
     elif dtype == np.bool:
         data = np.random.rand(*shape) > 0.5
     else:
-        data = np.random.uniform(0.01,1,*shape)
+        data = np.random.uniform(0.01, 1, shape)
     data = data.astype(dtype=dtype)
     if abs:
         return np.abs(data)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -109,7 +109,7 @@ def generate_random(shape: List[int], dtype: np.dtype,
     elif dtype == np.bool:
         data = np.random.rand(*shape) > 0.5
     else:
-        data = np.random.rand(*shape)
+        data = np.random.uniform(0.01,1,*shape)
     data = data.astype(dtype=dtype)
     if abs:
         return np.abs(data)


### PR DESCRIPTION
1. split fuse unary to target
2. limit the minimum value for random data
3. use 'uniform' to instead of 'rand'