### PR TITLE
Add Fold Conv2D+BatchNormal

### DIFF
--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -66,14 +66,19 @@ internal class Compiler : ICompiler
                 p.Add<Transform.Rules.Neutral.CombineTransposeUnary>();
                 p.Add<Transform.Rules.Neutral.CombineTransposePad>();
                 p.Add<Transform.Rules.Neutral.CombinePadTranspose>();
-                p.Add<Transform.Rules.Neutral.CombineTransposeBinary>();
+                p.Add<Transform.Rules.Neutral.CombineBinaryTranspose>();
+                p.Add<Transform.Rules.Neutral.CombineConstBinaryTranspose>();
                 p.Add<Transform.Rules.Neutral.CombineTransposeConstBinary>();
                 p.Add<Transform.Rules.Neutral.CombineTransposeReduce>();
                 p.Add<Transform.Rules.Neutral.CombineTransposeActivations>();
                 p.Add<Transform.Rules.Neutral.CombineActivationsTranspose>();
                 p.Add<Transform.Rules.Neutral.FoldNopPad>();
                 p.Add<Transform.Rules.Neutral.FoldConv2DPads>();
+                p.Add<Transform.Rules.Neutral.FoldConv2DMulAdd>();
                 p.Add<Transform.Rules.Neutral.FoldReduceWindow2DPads>();
+                p.Add<Transform.Rules.Neutral.ReluToClamp>();
+                p.Add<Transform.Rules.Neutral.CombineClampAdd>();
+                p.Add<Transform.Rules.Neutral.CombineClampMul>();
             });
         }
 

--- a/src/Nncase.Core/Diagnostics/DumpScope.cs
+++ b/src/Nncase.Core/Diagnostics/DumpScope.cs
@@ -24,12 +24,13 @@ public struct DumpScope : IDisposable
     /// Initializes a new instance of the <see cref="DumpScope"/> struct.
     /// </summary>
     /// <param name="subDirectory">Sub directory.</param>
+    /// <param name="dumpFlags">new dump Flags.</param>
     /// <param name="serviceProvider">Service provider.</param>
-    public DumpScope(string subDirectory, IServiceProvider? serviceProvider = null)
+    public DumpScope(string subDirectory, DumpFlags? dumpFlags = null, IServiceProvider? serviceProvider = null)
     {
         _initialized = true;
         _originalDumpper = GetCurrent(serviceProvider);
-        _dumpper.Value = _originalDumpper.CreateSubDummper(subDirectory);
+        _dumpper.Value = _originalDumpper.CreateSubDummper(subDirectory, dumpFlags);
     }
 
     /// <summary>

--- a/src/Nncase.Core/Diagnostics/IDumpper.cs
+++ b/src/Nncase.Core/Diagnostics/IDumpper.cs
@@ -32,8 +32,9 @@ public interface IDumpper
     /// Create sub dummper.
     /// </summary>
     /// <param name="subDirectory">Sub directory.</param>
+    /// <param name="dumpFlags">Sub dumpFlags.</param>
     /// <returns>Sub dummper.</returns>
-    IDumpper CreateSubDummper(string subDirectory);
+    IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags);
 
     void DumpIR(Expr expr, string prefix, string? reletivePath = null);
 

--- a/src/Nncase.Core/Diagnostics/IDumpper.cs
+++ b/src/Nncase.Core/Diagnostics/IDumpper.cs
@@ -34,7 +34,7 @@ public interface IDumpper
     /// <param name="subDirectory">Sub directory.</param>
     /// <param name="dumpFlags">Sub dumpFlags.</param>
     /// <returns>Sub dummper.</returns>
-    IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags);
+    IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags = null);
 
     void DumpIR(Expr expr, string prefix, string? reletivePath = null);
 

--- a/src/Nncase.Core/Diagnostics/NullDumpper.cs
+++ b/src/Nncase.Core/Diagnostics/NullDumpper.cs
@@ -24,13 +24,14 @@ public sealed class NullDumpper : IDumpper
     public string Directory => System.IO.Directory.GetCurrentDirectory();
 
     /// <inheritdoc/>
-    public IDumpper CreateSubDummper(string subDirectory) => this;
+    public IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags) => this;
 
     /// <inheritdoc/>
     public void DumpIR(Expr expr, string prefix, string? reletivePath = null)
     {
     }
 
+    /// <inheritdoc/>
     public void DumpDotIR(Expr expr, string prefix, string? reletivePath = null)
     {
     }

--- a/src/Nncase.Core/IR/Math/Clamp.cs
+++ b/src/Nncase.Core/IR/Math/Clamp.cs
@@ -24,12 +24,12 @@ public sealed record Clamp() : Op
     public static readonly ParameterInfo Input = new(typeof(Clamp), 0, "input");
 
     /// <summary>
-    /// Gets min.
+    /// Gets min. 
     /// </summary>
-    public static readonly ParameterInfo Min = new(typeof(Clamp), 1, "min", IsScalar());
+    public static readonly ParameterInfo Min = new(typeof(Clamp), 1, "min");
 
     /// <summary>
     /// Gets max.
     /// </summary>
-    public static readonly ParameterInfo Max = new(typeof(Clamp), 2, "max", IsScalar());
+    public static readonly ParameterInfo Max = new(typeof(Clamp), 2, "max");
 }

--- a/src/Nncase.Core/IR/Math/Clamp.cs
+++ b/src/Nncase.Core/IR/Math/Clamp.cs
@@ -24,7 +24,7 @@ public sealed record Clamp() : Op
     public static readonly ParameterInfo Input = new(typeof(Clamp), 0, "input");
 
     /// <summary>
-    /// Gets min. 
+    /// Gets min.
     /// </summary>
     public static readonly ParameterInfo Min = new(typeof(Clamp), 1, "min");
 

--- a/src/Nncase.Core/IR/Random/Normal.cs
+++ b/src/Nncase.Core/IR/Random/Normal.cs
@@ -32,4 +32,7 @@ public sealed record Normal(DataType Type) : Op
     /// Gets shape.
     /// </summary>
     public static readonly ParameterInfo Shape = new(typeof(Normal), 3, "shape", IsIntegral() & HasRank(1));
+
+    /// <inheritdoc/>
+    public override bool CanFoldConstCall => false;
 }

--- a/src/Nncase.Core/IR/Random/Normal.cs
+++ b/src/Nncase.Core/IR/Random/Normal.cs
@@ -33,6 +33,4 @@ public sealed record Normal(DataType Type) : Op
     /// </summary>
     public static readonly ParameterInfo Shape = new(typeof(Normal), 3, "shape", IsIntegral() & HasRank(1));
 
-    /// <inheritdoc/>
-    public override bool CanFoldConstCall => false;
 }

--- a/src/Nncase.Core/IR/Random/Normal.cs
+++ b/src/Nncase.Core/IR/Random/Normal.cs
@@ -32,5 +32,4 @@ public sealed record Normal(DataType Type) : Op
     /// Gets shape.
     /// </summary>
     public static readonly ParameterInfo Shape = new(typeof(Normal), 3, "shape", IsIntegral() & HasRank(1));
-
 }

--- a/src/Nncase.Core/PatternMatch/ExprPattern.cs
+++ b/src/Nncase.Core/PatternMatch/ExprPattern.cs
@@ -50,11 +50,19 @@ public static partial class Utility
     };
 
     /// <summary>
-    /// fast utility for build wildcard pattern.
+    /// build wildcard pattern.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public static ExprPattern IsWildcard(string? name) => new ExprPattern(name);
+
+    /// <summary>
+    /// fast utitlty for build condition.
     /// </summary>
     /// <param name="name">name.</param>
-    /// <returns> Returns. </returns>
-    public static ExprPattern IsWildcard(string? name) => new ExprPattern(name);
+    /// <param name="condition">conditions.</param>
+    /// <returns></returns>
+    public static ExprPattern IsWildcard(string? name, Func<Expr, bool> condition) => new ExprPattern(condition, name);
 
     /// <summary>
     /// <see cref="IsWildcard(string?)"/>.

--- a/src/Nncase.Core/Transform/PassManager.cs
+++ b/src/Nncase.Core/Transform/PassManager.cs
@@ -122,7 +122,7 @@ internal sealed class PassManager : IPassManager
     {
         Name = name;
         _compileSession = compileSession;
-        _dummper = DumpScope.GetCurrent(compileSession).CreateSubDummper(name);
+        _dummper = DumpScope.GetCurrent(compileSession).CreateSubDummper(name, null);
     }
 
     /// <summary>

--- a/src/Nncase.Diagnostics/Diagnostics/Dumpper.cs
+++ b/src/Nncase.Diagnostics/Diagnostics/Dumpper.cs
@@ -23,9 +23,9 @@ internal sealed class Dumpper : IDumpper
 
     public string Directory => _dumpDirectory;
 
-    public IDumpper CreateSubDummper(string subDirectory)
+    public IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags)
     {
-        return new Dumpper(_dumpFlags, Path.Join(_dumpDirectory, subDirectory));
+        return new Dumpper(dumpFlags ?? _dumpFlags, Path.Join(_dumpDirectory, subDirectory));
     }
 
     public void DumpIR(Expr expr, string prefix, string? reletivePath = null)

--- a/src/Nncase.Diagnostics/Diagnostics/Dumpper.cs
+++ b/src/Nncase.Diagnostics/Diagnostics/Dumpper.cs
@@ -25,7 +25,13 @@ internal sealed class Dumpper : IDumpper
 
     public IDumpper CreateSubDummper(string subDirectory, DumpFlags? dumpFlags)
     {
-        return new Dumpper(dumpFlags ?? _dumpFlags, Path.Join(_dumpDirectory, subDirectory));
+        DumpFlags subDumpFlags = _dumpFlags;
+        if (dumpFlags is DumpFlags flags)
+        {
+            subDumpFlags &= flags; // the sub dumpFlags must less than parents.
+        }
+
+        return new Dumpper(subDumpFlags, Path.Join(_dumpDirectory, subDirectory));
     }
 
     public void DumpIR(Expr expr, string prefix, string? reletivePath = null)

--- a/src/Nncase.EGraph/Transform/EGraphExtractor.cs
+++ b/src/Nncase.EGraph/Transform/EGraphExtractor.cs
@@ -129,7 +129,7 @@ internal class EGraphExtractor
         while (stack.Any())
         {
             (eclass, var minCostEnode) = stack.Peek();
-            if (_eclassMemo.TryGetValue(eclass, out _))
+            if (_eclassMemo.ContainsKey(eclass))
             {
                 stack.Pop();
                 continue;

--- a/src/Nncase.EGraph/Transform/EGraphExtractor.cs
+++ b/src/Nncase.EGraph/Transform/EGraphExtractor.cs
@@ -129,13 +129,13 @@ internal class EGraphExtractor
         while (stack.Any())
         {
             (eclass, var minCostEnode) = stack.Peek();
-            if (_eclassMemo.TryGetValue(eclass, out var expr))
+            if (_eclassMemo.TryGetValue(eclass, out _))
             {
                 stack.Pop();
                 continue;
             }
 
-            expr = null;
+            Expr? expr = null;
             switch (minCostEnode.Expr)
             {
                 case Var or TensorConst or TupleConst or Op or Fusion or None:

--- a/src/Nncase.EGraph/Transform/EGraphPrinter.cs
+++ b/src/Nncase.EGraph/Transform/EGraphPrinter.cs
@@ -208,7 +208,11 @@ public partial class EGraphPrinter
     /// <returns>this dot graph.</returns>
     public DotGraph SaveToStream(Stream output)
     {
-        DotGraph.Build(new StreamWriter(output, leaveOpen: true));
+        using (var writer = new StreamWriter(output))
+        {
+            DotGraph.Build(writer);
+        }
+
         return DotGraph;
     }
 

--- a/src/Nncase.EGraph/Transform/EGraphPrinter.cs
+++ b/src/Nncase.EGraph/Transform/EGraphPrinter.cs
@@ -208,7 +208,7 @@ public partial class EGraphPrinter
     /// <returns>this dot graph.</returns>
     public DotGraph SaveToStream(Stream output)
     {
-        using (var writer = new StreamWriter(output))
+        using (var writer = new StreamWriter(output, leaveOpen: true))
         {
             DotGraph.Build(writer);
         }

--- a/src/Nncase.Evaluator/EvaluateVisitor.cs
+++ b/src/Nncase.Evaluator/EvaluateVisitor.cs
@@ -23,7 +23,7 @@ internal sealed class EvaluateVisitor : ExprVisitor<IValue, IRType>, IDisposable
         _context = new EvaluateContext(ExpressionMemo);
         _evaluator_cache = evaluator_cache;
         _varsValues = varsValues;
-        _dumpManager = new EvaluatorDumpManager(DumpScope.Current.CreateSubDummper("Evaluate"), expr => _context.GetValue(expr).AsTensors());
+        _dumpManager = new EvaluatorDumpManager(DumpScope.Current.CreateSubDummper("Evaluate", null), expr => _context.GetValue(expr).AsTensors());
         _dumpManager.RegisterDumpCallbacks(RegisterBeforeCallback, RegisterAfterCallback);
     }
 

--- a/src/Nncase.Evaluator/Math/Clamp.cs
+++ b/src/Nncase.Evaluator/Math/Clamp.cs
@@ -60,12 +60,19 @@ public class ClampEvaluator : IEvaluator<Clamp>, ITypeInferencer<Clamp>, ICostEv
     private IRType Visit(TensorType input, TensorType min, TensorType max)
     {
         if (TypeInference.BroadcastType(input, min) is InvalidType invalidMin)
+        {
             return invalidMin;
+        }
+
         if (TypeInference.BroadcastType(input, max) is InvalidType invalidMax)
+        {
             return invalidMax;
+        }
 
         if (min.Shape != max.Shape)
+        {
             return new InvalidType($"The min.Shape {min.Shape} != max.Shape {max.Shape}");
+        }
 
         return input;
     }

--- a/src/Nncase.Importer/BaseImporter.cs
+++ b/src/Nncase.Importer/BaseImporter.cs
@@ -28,7 +28,7 @@ public abstract class BaseImporter
     public BaseImporter(CompileSession compileSession)
     {
         CompileSession = compileSession;
-        Dumpper = DumpScope.GetCurrent(compileSession).CreateSubDummper("Import");
+        Dumpper = DumpScope.GetCurrent(compileSession).CreateSubDummper("Import", null);
     }
 
     /// <summary>

--- a/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
+++ b/src/Nncase.Tests/Evaluator/UnitTestEvaluatorMath.cs
@@ -25,6 +25,13 @@ namespace Nncase.Tests.EvaluatorTest;
 
 public class UnitTestEvaluatorMath : TestClassBase
 {
+    public static TheoryData<int[], int[], int[]> ClampInvalidTypeData = new()
+    {
+        { new[] { 1, 2, 3, 4 }, new[] { 8 }, new[] { 8 } },
+        { new[] { 1, 2, 3, 4 }, new[] { 4 }, new[] { 8 } },
+        { new[] { 1, 2, 3, 4 }, new[] { 4 }, new[] { 1 } },
+    };
+
     [Fact]
     public void TestBinaryScalarScalar()
     {
@@ -333,6 +340,18 @@ public class UnitTestEvaluatorMath : TestClassBase
         var min = 3U;
         var max = 6L;
         var expr = IR.F.Math.Clamp(Tensor.From(input, new[] { 2, 4 }), min, max);
+        CompilerServices.InferenceType(expr);
+        Assert.IsType<InvalidType>(expr.CheckedType);
+    }
+
+    [Theory]
+    [MemberData(nameof(ClampInvalidTypeData))]
+    public void TestClampInvalidType2(int[] inputShape, int[] minShape, int[] maxShape)
+    {
+        var input = Tensor.FromScalar<float>(3.3f, inputShape);
+        var min = Tensor.FromScalar<float>(0.0f, minShape);
+        var max = Tensor.FromScalar<float>(6.0f, maxShape);
+        var expr = IR.F.Math.Clamp(input, min, max);
         CompilerServices.InferenceType(expr);
         Assert.IsType<InvalidType>(expr.CheckedType);
     }

--- a/src/Nncase.Tests/Rewrite/RewriteBase.cs
+++ b/src/Nncase.Tests/Rewrite/RewriteBase.cs
@@ -310,27 +310,27 @@ public class MobileNetV1TransposeCase : IRewriteCase
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,112,112,32]
-            var v_6 = Transpose(v_5, new[] { 0, 3, 1, 2 }); // f32[1,32,112,112]
-            var v_7 = Conv2D(
-                v_6,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,112,112,32]
+            var v6 = Transpose(v5, new[] { 0, 3, 1, 2 }); // f32[1,32,112,112]
+            var v7 = Conv2D(
+                v6,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, 32, 1, 1 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 0, 0 },
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,64,112,112]
-            var v_8 = Transpose(v_7, new[] { 0, 2, 3, 1 }); // f32[1,112,112,64]
-            var v_9 = Pad(v_8, new[,]
+            var v8 = Transpose(v7, new[] { 0, 2, 3, 1 }); // f32[1,112,112,64]
+            var v9 = Pad(v8, new[,]
             {
                 { 0, 0 },
                 { 0, 1 },
                 { 0, 1 },
                 { 0, 0 },
             }, PadMode.Constant, 0.0f); // f32[1,113,113,64]
-            var v_10 = Transpose(v_9, new[] { 0, 3, 1, 2 }); // f32[1,64,113,113]
-            var v_11 = Conv2D(
-                v_10,
+            var v10 = Transpose(v9, new[] { 0, 3, 1, 2 }); // f32[1,64,113,113]
+            var v11 = Conv2D(
+                v10,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, 1, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(),
                 new[] { 2, 2 }, new[,]
@@ -339,7 +339,7 @@ public class MobileNetV1TransposeCase : IRewriteCase
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 64,
                 new[] { 0.0f, 6.0f }); // f32[1,64,56,56]
-            return new Function(v_11, new Var[] { _input });
+            return new Function(v11, new Var[] { _input });
         }
     }
 
@@ -373,30 +373,30 @@ public class PadTransposeCase : IRewriteCase
     {
         get
         {
-            var v_0 = Pad(_input, new[,]
+            var v0 = Pad(_input, new[,]
             {
                 { 0, 0 },
                 { 2, 2 },
                 { 2, 2 },
                 { 0, 0 },
             }, PadMode.Constant, 0.0f); // f32[1,14,14,16]
-            var v_1 = Transpose(v_0, new[] { 0, 3, 1, 2 }); // f32[1,16,14,14]
-            var v_2 = Conv2D(
-                v_1,
+            var v1 = Transpose(v0, new[] { 0, 3, 1, 2 }); // f32[1,16,14,14]
+            var v2 = Conv2D(
+                v1,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 0, 0 },
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,64,12,12]
-            var v_3 = Pad(v_2, new[,]
+            var v3 = Pad(v2, new[,]
             {
                 { 0, 0 },
                 { 0, 0 },
                 { 0, 0 },
                 { 0, 0 },
             }, PadMode.Constant, 0.0f); // f32[1,64,12,12]
-            return new Function(v_3, new Var[] { _input });
+            return new Function(v3, new Var[] { _input });
         }
     }
 
@@ -438,18 +438,18 @@ public sealed class TransposeLeakyRelu : IRewriteCase
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = LeakyRelu(v_5, 0.1f); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = LeakyRelu(v5, 0.1f); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 
@@ -480,18 +480,18 @@ public class ActivationsTranspose : IRewriteCase
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = LeakyRelu(v_5, 0.1f); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = LeakyRelu(v5, 0.1f); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 
@@ -515,18 +515,18 @@ public sealed class ActivationsTranspose2 : ActivationsTranspose
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = Relu(v_5); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = Relu(v5); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 }
@@ -540,18 +540,18 @@ public sealed class ActivationsTransposePRelu : ActivationsTranspose
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = PRelu(v_5, Tensor.From(Enumerable.Repeat(0.2f, 16).ToArray(), new[] { 1, 1, 16 })); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = PRelu(v5, Tensor.From(Enumerable.Repeat(0.2f, 16).ToArray(), new[] { 1, 1, 16 })); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 }
@@ -562,18 +562,18 @@ public sealed class ActivationsTransposePRelu2 : ActivationsTranspose
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = PRelu(v_5, Tensor.From(Enumerable.Repeat(0.2f, 16).ToArray(), new[] { 1, 1, 1, 16 })); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = PRelu(v5, Tensor.From(Enumerable.Repeat(0.2f, 16).ToArray(), new[] { 1, 1, 1, 16 })); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 }
@@ -587,18 +587,18 @@ public sealed class ActivationsTransposePRelu3 : ActivationsTranspose
     {
         get
         {
-            var v_5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
-            var v_6 = PRelu(v_5, Tensor.FromScalar(0.2f)); // f32[1,15,20,16]
-            var v_7 = Transpose(v_6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
-            var v_8 = Conv2D(
-                v_7,
+            var v5 = Transpose(_input, new[] { 0, 2, 3, 1 }); // f32[1,15,20,16]
+            var v6 = PRelu(v5, Tensor.FromScalar(0.2f)); // f32[1,15,20,16]
+            var v7 = Transpose(v6, new[] { 0, 3, 1, 2 }); // f32[1,16,15,20]
+            var v8 = Conv2D(
+                v7,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 }
@@ -616,19 +616,19 @@ public sealed class RemoveMarkerCaseEgraph : IRewriteCase
     {
         get
         {
-            var v_5 = RangeOfMarker(Transpose(_input, new[] { 0, 2, 3, 1 }), new float[] { float.NegativeInfinity, float.PositiveInfinity }); // f32[1,15,20,16]
-            var v_6 = RangeOfMarker(Relu6(v_5), new float[] { 0.0f, 6.0f }); // f32[1,15,20,16]
-            var v_7 = RangeOfMarker(Transpose(v_6, new[] { 0, 3, 1, 2 }), new float[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            var v_8 = RangeOfMarker(
+            var v5 = RangeOfMarker(Transpose(_input, new[] { 0, 2, 3, 1 }), new float[] { float.NegativeInfinity, float.PositiveInfinity }); // f32[1,15,20,16]
+            var v6 = RangeOfMarker(Relu6(v5), new float[] { 0.0f, 6.0f }); // f32[1,15,20,16]
+            var v7 = RangeOfMarker(Transpose(v6, new[] { 0, 3, 1, 2 }), new float[] { 0.0f, 6.0f }); // f32[1,16,15,20]
+            var v8 = RangeOfMarker(
                 Conv2D(
-                v_7,
+                v7,
                 RangeOfMarker(Normal(DataTypes.Float32, 0, 1, 1, new[] { 16, 16, 3, 3 }).Evaluate().AsTensor(), new float[] { -1.0f, 1.0f }),
                 RangeOfMarker(Normal(DataTypes.Float32, 0, 1, 1, new[] { 16 }).Evaluate().AsTensor(), new float[] { -1.0f, 1.0f }), new[] { 1, 1 }, new[,]
                 {
                     { 1, 1 },
                     { 1, 1 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { 0.0f, 6.0f }), new float[] { 0.0f, 6.0f }); // f32[1,16,15,20]
-            return new Function(v_8, new Var[] { _input });
+            return new Function(v8, new Var[] { _input });
         }
     }
 
@@ -660,7 +660,7 @@ public sealed class Conv2DPadsCase : IRewriteCase
     {
         get
         {
-            var v_12 = Conv2D(
+            var v12 = Conv2D(
                 _input,
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 96, 16, 1, 1 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 96 }).Evaluate().AsTensor(), new[] { 1, 1 },
@@ -670,14 +670,14 @@ public sealed class Conv2DPadsCase : IRewriteCase
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1,
                 new[] { 0.0f, 6.0f }); // f32[1,96,56,56]
-            var v_13 = Pad(v_12, new[,]
+            var v13 = Pad(v12, new[,]
             {
                 { 0, 0 },
                 { 0, 0 },
                 { 0, 1 },
                 { 0, 1 },
             }, PadMode.Constant, 0.0f); // f32[1,96,57,57]
-            var v_14 = Conv2D(v_13, Normal(DataTypes.Float32, 0, 1, 1, new[] { 96, 1, 3, 3 }).Evaluate().AsTensor(),
+            var v14 = Conv2D(v13, Normal(DataTypes.Float32, 0, 1, 1, new[] { 96, 1, 3, 3 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 96 }).Evaluate().AsTensor(), new[] { 2, 2 },
                 new[,]
                 {
@@ -685,7 +685,7 @@ public sealed class Conv2DPadsCase : IRewriteCase
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 96,
                 new[] { 0.0f, 6.0f }); // f32[1,96,28,28]
-            return new Function(v_14, new Var[] { _input });
+            return new Function(v14, new Var[] { _input });
         }
     }
 
@@ -713,7 +713,7 @@ public sealed class ReduceWindow2DPadsCase : IRewriteCase
     {
         get
         {
-            var v_0 = Conv2D(_input, Normal(DataTypes.Float32, 0, 1, 1, new[] { 96, 16, 1, 1 }).Evaluate().AsTensor(),
+            var v0 = Conv2D(_input, Normal(DataTypes.Float32, 0, 1, 1, new[] { 96, 16, 1, 1 }).Evaluate().AsTensor(),
                 Normal(DataTypes.Float32, 0, 1, 1, new[] { 96 }).Evaluate().AsTensor(), new[] { 1, 1 },
                 new[,]
                 {
@@ -721,20 +721,20 @@ public sealed class ReduceWindow2DPadsCase : IRewriteCase
                     { 0, 0 },
                 }, new[] { 1, 1 }, PadMode.Constant, 1,
                 new[] { 0.0f, 6.0f }); // f32[1,96,56,56]
-            var v_1 = Pad(v_0, new[,]
+            var v1 = Pad(v0, new[,]
             {
                 { 0, 0 },
                 { 0, 0 },
                 { 0, 1 },
                 { 0, 1 },
             }, PadMode.Constant, 0.0f); // f32[1,96,57,57]
-            var v_2 = ReduceWindow2D(ReduceOp.Max, v_1, 0, new[] { 3, 3 }, new[] { 2, 2 },
+            var v2 = ReduceWindow2D(ReduceOp.Max, v1, 0, new[] { 3, 3 }, new[] { 2, 2 },
                 new[,]
                 {
                     { 0, 0 },
                     { 0, 0 },
                 }, new[] { 1, 1 }, false, false); // f32[1,96,28,28]
-            return new Function(v_2, new Var[] { _input });
+            return new Function(v2, new Var[] { _input });
         }
     }
 
@@ -751,25 +751,25 @@ public sealed class ReduceWindow2DPadsCase : IRewriteCase
 
 public sealed class MergeBinaryBeforeConv2DCase : IRewriteCase
 {
-    private readonly Var _input_lhs;
-    private readonly Var _input_rhs;
+    private readonly Var _inputLhs;
+    private readonly Var _inputRhs;
 
     public MergeBinaryBeforeConv2DCase()
     {
-        _input_lhs = new Var("_input_lhs", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
-        _input_rhs = new Var("_input_rhs", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+        _inputLhs = new Var("_inputLhs", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+        _inputRhs = new Var("_inputRhs", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
     }
 
     public Function PreExpr
     {
         get
         {
-            var v_0 = _input_lhs + _input_rhs;
-            var v_1 = v_0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { 1, 256, 1, 1 }).Evaluate().AsTensor();
-            var v_2 = v_1 + Normal(DataTypes.Float32, 0, 1, 1, new[] { 1, 256, 1, 1 }).Evaluate().AsTensor();
-            var v_3 = v_2; // 1, 56, 56, 256
-            var v_4 = v_3;
-            var v_5 = Conv2D(v_4, Normal(DataTypes.Float32, 0, 1, 1, new[] { 256, 256, 1, 1 }).Evaluate().AsTensor(),
+            var v0 = _inputLhs + _inputRhs;
+            var v1 = v0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { 1, 256, 1, 1 }).Evaluate().AsTensor();
+            var v2 = v1 + Normal(DataTypes.Float32, 0, 1, 1, new[] { 1, 256, 1, 1 }).Evaluate().AsTensor();
+            var v3 = v2; // 1, 56, 56, 256
+            var v4 = v3;
+            var v5 = Conv2D(v4, Normal(DataTypes.Float32, 0, 1, 1, new[] { 256, 256, 1, 1 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 1, new[] { 256 }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -777,16 +777,16 @@ public sealed class MergeBinaryBeforeConv2DCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,256,56,56]
-            var v_6 = v_5; // f32[1,256,56,56]
-            var v_7 = Pad(v_6, new[,]
+            var v6 = v5; // f32[1,256,56,56]
+            var v7 = Pad(v6, new[,]
             {
                 { 0, 0 },
                 { 0, 0 },
                 { 1, 1 },
                 { 1, 1 },
             }, PadMode.Constant, 0.0f); // f32[1,256,58,58]
-            var v_8 = v_7;
-            var v_9 = Conv2D(v_8, Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, 256, 3, 3 }).Evaluate().AsTensor(),
+            var v8 = v7;
+            var v9 = Conv2D(v8, Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, 256, 3, 3 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -794,10 +794,10 @@ public sealed class MergeBinaryBeforeConv2DCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,64,56,56]
-            var v_10 = v_9; // f32[1,64,56,56]
+            var v10 = v9; // f32[1,64,56,56]
 
-            var v_11 = v_10;
-            var v_12 = Conv2D(v_11, Normal(DataTypes.Float32, 0, 1, 1, new[] { 256, 64, 1, 1 }).Evaluate().AsTensor(),
+            var v11 = v10;
+            var v12 = Conv2D(v11, Normal(DataTypes.Float32, 0, 1, 1, new[] { 256, 64, 1, 1 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 1, new[] { 256 }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -805,10 +805,10 @@ public sealed class MergeBinaryBeforeConv2DCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,256,56,56]
-            var v_13 = v_12; // f32[1,256,56,56]
-            var v_16 = v_0 + v_13;
+            var v13 = v12; // f32[1,256,56,56]
+            var v16 = v0 + v13;
 
-            return new Function(v_16, new Var[] { _input_lhs, _input_rhs });
+            return new Function(v16, new Var[] { _inputLhs, _inputRhs });
         }
     }
 
@@ -820,8 +820,8 @@ public sealed class MergeBinaryBeforeConv2DCase : IRewriteCase
 
     public Dictionary<Var, IValue> FeedDict => new()
     {
-        { _input_lhs, Normal(DataTypes.Float32, 0, 1, 1, _input_lhs.CheckedShape.ToValueArray()).Evaluate() },
-        { _input_rhs, Normal(DataTypes.Float32, 0, 1, 1, _input_rhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputLhs, Normal(DataTypes.Float32, 0, 1, 1, _inputLhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputRhs, Normal(DataTypes.Float32, 0, 1, 1, _inputRhs.CheckedShape.ToValueArray()).Evaluate() },
     };
 }
 
@@ -829,24 +829,24 @@ public sealed class CombineClampAddMul : IRewriteCase
 {
     private const int _channels = 4; // 256
     private const int _featrueMap = 3; // 56
-    private readonly Var _input_lhs;
-    private readonly Var _input_rhs;
+    private readonly Var _inputLhs;
+    private readonly Var _inputRhs;
 
     public CombineClampAddMul()
     {
-        _input_lhs = new Var("_input_lhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
-        _input_rhs = new Var("_input_rhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
+        _inputLhs = new Var("_inputLhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
+        _inputRhs = new Var("_inputRhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
     }
 
     public Function PreExpr
     {
         get
         {
-            var v_0 = _input_lhs + _input_rhs; // [1,_featrueMap,_featrueMap,_channels]
-            var v_1 = v_0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { _channels }).Evaluate().AsTensor();
-            var v_2 = v_1 + Normal(DataTypes.Float32, 0, 1, 2, new[] { _channels }).Evaluate().AsTensor();
-            var v_3 = Relu(v_2);
-            return new Function(v_3, new Var[] { _input_lhs, _input_rhs });
+            var v0 = _inputLhs + _inputRhs; // [1,_featrueMap,_featrueMap,_channels]
+            var v1 = v0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { _channels }).Evaluate().AsTensor();
+            var v2 = v1 + Normal(DataTypes.Float32, 0, 1, 2, new[] { _channels }).Evaluate().AsTensor();
+            var v3 = Relu(v2);
+            return new Function(v3, new Var[] { _inputLhs, _inputRhs });
         }
     }
 
@@ -859,8 +859,8 @@ public sealed class CombineClampAddMul : IRewriteCase
 
     public Dictionary<Var, IValue> FeedDict => new()
     {
-        { _input_lhs, Normal(DataTypes.Float32, 0, 1, 5, _input_lhs.CheckedShape.ToValueArray()).Evaluate() },
-        { _input_rhs, Normal(DataTypes.Float32, 0, 1, 6, _input_rhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputLhs, Normal(DataTypes.Float32, 0, 1, 5, _inputLhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputRhs, Normal(DataTypes.Float32, 0, 1, 6, _inputRhs.CheckedShape.ToValueArray()).Evaluate() },
     };
 
     public bool CheckPostCallBack(Function post)
@@ -873,25 +873,25 @@ public sealed class FoldConv2DBnCase : IRewriteCase
 {
     private const int _channels = 16; // 256
     private const int _featrueMap = 8; // 56
-    private readonly Var _input_lhs;
-    private readonly Var _input_rhs;
+    private readonly Var _inputLhs;
+    private readonly Var _inputRhs;
 
     public FoldConv2DBnCase()
     {
-        _input_lhs = new Var("_input_lhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
-        _input_rhs = new Var("_input_rhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
+        _inputLhs = new Var("_inputLhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
+        _inputRhs = new Var("_inputRhs", new TensorType(DataTypes.Float32, new[] { 1, _featrueMap, _featrueMap, _channels }));
     }
 
     public Function PreExpr
     {
         get
         {
-            var v_0 = _input_lhs + _input_rhs; // [1,_featrueMap,_featrueMap,_channels]
-            var v_1 = v_0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { _channels }).Evaluate().AsTensor();
-            var v_2 = v_1 + Normal(DataTypes.Float32, 0, 1, 2, new[] { _channels }).Evaluate().AsTensor();
-            var v_3 = Relu(v_2);
-            var v_4 = NHWCToNCHW(v_3);
-            var v_5 = Conv2D(v_4, Normal(DataTypes.Float32, 0, 1, 3, new[] { _channels, _channels, 1, 1 }).Evaluate().AsTensor(),
+            var v0 = _inputLhs + _inputRhs; // [1,_featrueMap,_featrueMap,_channels]
+            var v1 = v0 * Normal(DataTypes.Float32, 0, 1, 1, new[] { _channels }).Evaluate().AsTensor();
+            var v2 = v1 + Normal(DataTypes.Float32, 0, 1, 2, new[] { _channels }).Evaluate().AsTensor();
+            var v3 = Relu(v2);
+            var v4 = NHWCToNCHW(v3);
+            var v5 = Conv2D(v4, Normal(DataTypes.Float32, 0, 1, 3, new[] { _channels, _channels, 1, 1 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 1, new[] { _channels }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -899,16 +899,16 @@ public sealed class FoldConv2DBnCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,_channels,_featrueMap,_featrueMap]
-            var v_6 = NCHWToNHWC(v_5); // f32[1,_featrueMap,_featrueMap,_channels]
-            var v_7 = Pad(v_6, new[,]
+            var v6 = NCHWToNHWC(v5); // f32[1,_featrueMap,_featrueMap,_channels]
+            var v7 = Pad(v6, new[,]
             {
                 { 0, 0 },
                 { 1, 1 },
                 { 1, 1 },
                 { 0, 0 },
             }, PadMode.Constant, 0.0f); // f32[1,58,58,_channels]
-            var v_8 = NHWCToNCHW(v_7);
-            var v_9 = Conv2D(v_8, Normal(DataTypes.Float32, 0, 1, 4, new[] { 64, _channels, 3, 3 }).Evaluate().AsTensor(),
+            var v8 = NHWCToNCHW(v7);
+            var v9 = Conv2D(v8, Normal(DataTypes.Float32, 0, 1, 4, new[] { 64, _channels, 3, 3 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 5, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -916,9 +916,9 @@ public sealed class FoldConv2DBnCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,64,_featrueMap,_featrueMap]
-            var v_10 = NCHWToNHWC(v_9); // f32[1,_featrueMap,_featrueMap,64]
-            var v_11 = NHWCToNCHW(v_10);
-            var v_12 = Conv2D(v_11, Normal(DataTypes.Float32, 0, 1, 6, new[] { _channels, 64, 1, 1 }).Evaluate().AsTensor(),
+            var v10 = NCHWToNHWC(v9); // f32[1,_featrueMap,_featrueMap,64]
+            var v11 = NHWCToNCHW(v10);
+            var v12 = Conv2D(v11, Normal(DataTypes.Float32, 0, 1, 6, new[] { _channels, 64, 1, 1 }).Evaluate().AsTensor(),
                   Normal(DataTypes.Float32, 0, 1, 7, new[] { _channels }).Evaluate().AsTensor(), new[] { 1, 1 },
                   new[,]
                   {
@@ -926,10 +926,10 @@ public sealed class FoldConv2DBnCase : IRewriteCase
                     { 0, 0 },
                   }, new[] { 1, 1 }, PadMode.Constant, 1,
                   new[] { 0.0f, 6.0f }); // f32[1,_channels,_featrueMap,_featrueMap]
-            var v_13 = NCHWToNHWC(v_12); // f32[1,_featrueMap,_featrueMap,_channels]
-            var v_16 = v_0 + v_13;
+            var v13 = NCHWToNHWC(v12); // f32[1,_featrueMap,_featrueMap,_channels]
+            var v16 = v0 + v13;
 
-            return new Function(v_16, new Var[] { _input_lhs, _input_rhs });
+            return new Function(v16, new Var[] { _inputLhs, _inputRhs });
         }
     }
 
@@ -950,8 +950,8 @@ public sealed class FoldConv2DBnCase : IRewriteCase
 
     public Dictionary<Var, IValue> FeedDict => new()
     {
-        { _input_lhs, Normal(DataTypes.Float32, 0, 1, 1, _input_lhs.CheckedShape.ToValueArray()).Evaluate() },
-        { _input_rhs, Normal(DataTypes.Float32, 0, 1, 1, _input_rhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputLhs, Normal(DataTypes.Float32, 0, 1, 1, _inputLhs.CheckedShape.ToValueArray()).Evaluate() },
+        { _inputRhs, Normal(DataTypes.Float32, 0, 1, 1, _inputRhs.CheckedShape.ToValueArray()).Evaluate() },
     };
 
     public bool CheckPostCallBack(Function post)

--- a/src/Nncase.Tests/Rewrite/RewriteBase.cs
+++ b/src/Nncase.Tests/Rewrite/RewriteBase.cs
@@ -46,7 +46,7 @@ public interface IRewriteCase
     /// </summary>
     /// <param name="post"></param>
     /// <returns></returns>
-    bool CheckPostCallBack(Function post) => true;
+    bool ChecksPostCallBack(Function post) => true;
 }
 
 public static class DummyOp
@@ -863,7 +863,7 @@ public sealed class CombineClampAddMul : IRewriteCase
         { _inputRhs, Normal(DataTypes.Float32, 0, 1, 6, _inputRhs.CheckedShape.ToValueArray()).Evaluate() },
     };
 
-    public bool CheckPostCallBack(Function post)
+    public bool ChecksPostCallBack(Function post)
     {
         return true;
     }
@@ -954,7 +954,7 @@ public sealed class FoldConv2DBnCase : IRewriteCase
         { _inputRhs, Normal(DataTypes.Float32, 0, 1, 1, _inputRhs.CheckedShape.ToValueArray()).Evaluate() },
     };
 
-    public bool CheckPostCallBack(Function post)
+    public bool ChecksPostCallBack(Function post)
     {
         return true;
     }

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
@@ -23,75 +23,8 @@ using Tuple = Nncase.IR.Tuple;
 namespace Nncase.Tests.ReWriteTest;
 
 [AutoSetupTestMethod(InitSession = true)]
-public class UnitTestDataFlowRewriteFactory : TestClassBase
-{
-    public static TheoryData<IRewriteCase> DataOne => new()
-    {
-    };
-
-    public static TheoryData<IRewriteCase> DataAll => new()
-    {
-        new MergeBinaryBeforeConv2DCase(),
-        new ActivationsTransposePRelu(),
-        new ActivationsTransposePRelu2(),
-        new ActivationsTransposePRelu3(),
-        new ActivationsTranspose(),
-        new ActivationsTranspose2(),
-        new PadTransposeCase(),
-        new TransposeLeakyRelu(),
-        new Conv2DPadsCase(),
-        new ReduceWindow2DPadsCase(),
-        new MobileNetV1TransposeCase(),
-    };
-
-    [Theory]
-    [MemberData(nameof(DataOne))]
-    public Task RunOneAsync(IRewriteCase @case) => RunCoreAsync(@case);
-
-    [Theory]
-    [MemberData(nameof(DataAll))]
-    public Task RunAllAsync(IRewriteCase @case) => RunCoreAsync(@case);
-
-    private async Task RunCoreAsync(IRewriteCase @case)
-    {
-        var pre = @case.PreExpr;
-        var pass = new DataflowPass { Name = "DataFlowOptimize" };
-        foreach (var rule in @case.Rules)
-        {
-            pass.Add(rule);
-        }
-
-        var post = (Function)await pass.RunAsync(pre, new());
-        Assert.NotEqual(pre, post);
-        var feed_dict = @case.FeedDict;
-        Assert.True(Comparator.Compare(pre.Body.Evaluate(feed_dict), post.Body.Evaluate(feed_dict)));
-    }
-}
-
-[AutoSetupTestMethod(InitSession = true)]
 public class UnitTestDataFlowRewrite : RewriteFixtrue
 {
-    // [Fact]
-    // public void TestSwapXY()
-    // {
-    //     var lhs = (Var)"x";
-    //     var rhs = (Const)1;
-    //     var pre = (lhs + rhs) * 10;
-
-    // var post = CompilerServices.Rewrite(pre, new[] { new SwapXY() }, RunPassContext.Invalid);
-    //     Assert.Equal(post, (rhs + lhs) * 10);
-    // }
-
-    // [Fact]
-    // public void TestRemoveShapeOp()
-    // {
-    //     var lhs = new Var("x", new TensorType(DataTypes.Float32, new[] { 1, 1, 3 }));
-    //     var rhs = torch.rand(1, 6, 3, torch.ScalarType.Float32).ToTensor();
-    //     var pre = ShapeOf(lhs + rhs);
-    //     Assert.True(CompilerServices.InferenceType(pre));
-    //     var post = CompilerServices.Rewrite(pre, new[] { new Transform.Pass.FoldShapeOp() }, RunPassContext.Invalid);
-    //     Assert.Equal(new[] { 1, 6, 3 }, ((TensorConst)post).Value.Cast<int>().ToArray());
-    // }
     [Fact]
     public void TestFoldConstCall()
     {

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewrite.cs
@@ -27,11 +27,11 @@ public class UnitTestDataFlowRewriteFactory : TestClassBase
 {
     public static TheoryData<IRewriteCase> DataOne => new()
     {
-        new MergeBinaryBeforeConv2DCase(),
     };
 
     public static TheoryData<IRewriteCase> DataAll => new()
     {
+        new MergeBinaryBeforeConv2DCase(),
         new ActivationsTransposePRelu(),
         new ActivationsTransposePRelu2(),
         new ActivationsTransposePRelu3(),

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
@@ -43,7 +43,7 @@ public class UnitTestDataFlowRewriteFactory : TestClassBase
 
     private async Task RunCoreAsync(IRewriteCase @case)
     {
-        var _ = new DumpScope($"../{@case.Name}", DumpFlags.None);
+        using var dumpScope = new DumpScope($"../{@case.Name}", DumpFlags.None);
         var pre = @case.PreExpr;
         CompilerServices.InferenceType(pre);
 #if DEBUG

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
@@ -46,7 +46,9 @@ public class UnitTestDataFlowRewriteFactory : TestClassBase
         var _ = new DumpScope($"../{@case.Name}", DumpFlags.None);
         var pre = @case.PreExpr;
         CompilerServices.InferenceType(pre);
+#if DEBUG
         DumpScope.Current.DumpIR(pre, "pre");
+#endif
         var pass = new DataflowPass { Name = "DataFlowOptimize" };
         foreach (var rule in @case.Rules)
         {
@@ -54,7 +56,9 @@ public class UnitTestDataFlowRewriteFactory : TestClassBase
         }
 
         var post = (Function)await pass.RunAsync(pre, new());
+#if DEBUG
         DumpScope.Current.DumpIR(post, "post");
+#endif
         Assert.NotEqual(pre, post);
         var feed_dict = @case.FeedDict;
         IValue preValue, postValue;

--- a/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestDataFlowRewriteFactory.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Nncase.Diagnostics;
+using Nncase.IR;
+using Nncase.Tests.TestFixture;
+using Nncase.Transform;
+using Xunit;
+
+namespace Nncase.Tests.ReWriteTest;
+
+[AutoSetupTestMethod(InitSession = true)]
+public class UnitTestDataFlowRewriteFactory : TestClassBase
+{
+    public static TheoryData<IRewriteCase> DataOne => new()
+    {
+        new CombineClampAddMul(),
+    };
+
+    public static TheoryData<IRewriteCase> DataAll => new()
+    {
+        new MergeBinaryBeforeConv2DCase(),
+        new ActivationsTransposePRelu(),
+        new ActivationsTransposePRelu2(),
+        new ActivationsTransposePRelu3(),
+        new ActivationsTranspose(),
+        new ActivationsTranspose2(),
+        new PadTransposeCase(),
+        new TransposeLeakyRelu(),
+        new Conv2DPadsCase(),
+        new ReduceWindow2DPadsCase(),
+        new MobileNetV1TransposeCase(),
+    };
+
+    [Theory]
+    [MemberData(nameof(DataOne))]
+    public Task RunOneAsync(IRewriteCase @case) => RunCoreAsync(@case);
+
+    [Theory]
+    [MemberData(nameof(DataAll))]
+    public Task RunAllAsync(IRewriteCase @case) => RunCoreAsync(@case);
+
+    private async Task RunCoreAsync(IRewriteCase @case)
+    {
+        var _ = new DumpScope($"../{@case.Name}", DumpFlags.None);
+        var pre = @case.PreExpr;
+        CompilerServices.InferenceType(pre);
+        DumpScope.Current.DumpIR(pre, "pre");
+        var pass = new DataflowPass { Name = "DataFlowOptimize" };
+        foreach (var rule in @case.Rules)
+        {
+            pass.Add(rule);
+        }
+
+        var post = (Function)await pass.RunAsync(pre, new());
+        DumpScope.Current.DumpIR(post, "post");
+        Assert.NotEqual(pre, post);
+        var feed_dict = @case.FeedDict;
+        IValue preValue, postValue;
+        using (var preScope = new DumpScope("Pre", DumpFlags.None))
+        {
+            preValue = pre.Body.Evaluate(feed_dict);
+        }
+
+        using (var postScope = new DumpScope("Post", DumpFlags.None))
+        {
+            postValue = post.Body.Evaluate(feed_dict);
+        }
+
+        Assert.True(Comparator.Compare(preValue, postValue));
+    }
+}

--- a/src/Nncase.Tests/Rewrite/UnitTestEGraphRewrite.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestEGraphRewrite.cs
@@ -74,7 +74,7 @@ public class UnitTestEGraphRewrite : TestClassBase
 
         Assert.True(pre.InferenceType());
 
-        var post = CompilerServices.ERewrite(pre, new[] { new Transform.Rules.Neutral.CombineTransposeBinary() }, new());
+        var post = CompilerServices.ERewrite(pre, new[] { new Transform.Rules.Neutral.CombineBinaryTranspose() }, new());
 
         Assert.True(post.InferenceType());
         Assert.Equal(pre.Evaluate(), post.Evaluate());

--- a/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
@@ -91,7 +91,7 @@ public sealed class UnitTestEGraphRewriteFactory : TestClassBase
 #if DEBUG
         DumpScope.Current.DumpIR(post, "post");
 #endif
-        Assert.True(@case.CheckPostCallBack(post));
+        Assert.True(@case.ChecksPostCallBack(post));
 
         IValue pre_ret, post_ret;
         var feedDict = @case.FeedDict;

--- a/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestEGraphRewriteFactory.cs
@@ -69,7 +69,11 @@ public sealed class UnitTestEGraphRewriteFactory : TestClassBase
 
     private async Task RunCoreAsync(IRewriteCase @case)
     {
-        using var dumpScope = new DumpScope($"../{@case.Name}", DumpFlags.EGraphCost);
+        DumpFlags dumpFlag = DumpFlags.None;
+#if DEBUG
+        dumpFlag = DumpFlags.EGraphCost;
+#endif
+        using var dumpScope = new DumpScope($"../{@case.Name}", dumpFlag);
         var pre = @case.PreExpr;
         var infered = pre.InferenceType();
         Assert.True(infered);
@@ -84,7 +88,9 @@ public sealed class UnitTestEGraphRewriteFactory : TestClassBase
         post = (Function)await pass.RunAsync(pre, new());
         Assert.True(post.InferenceType());
 
+#if DEBUG
         DumpScope.Current.DumpIR(post, "post");
+#endif
         Assert.True(@case.CheckPostCallBack(post));
 
         IValue pre_ret, post_ret;

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestCombineBinary.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestCombineBinary.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.HighPerformance;
+using Nncase.IR;
+using Nncase.Transform;
+using Xunit;
+
+namespace Nncase.Tests.Rules.NeutralTest;
+
+public class UnitTestCombineBinary : TestFixture.UnitTestFixtrue
+{
+    public static IEnumerable<object[]> CombineClampBinaryPositiveData
+    {
+        get
+        {
+            var inputShapes = new object[]{
+              new []{1,32,24,24},
+            };
+            var constShapes = new object[]{
+              new []{32},
+              new []{24,24,32}
+            };
+            var clampShapes = new object[]{
+              Array.Empty<int>(),
+              new []{32},
+              new []{24,24,32}
+            };
+            var mins = new object[]{
+              0.0f,float.NegativeInfinity
+            };
+            var maxs = new object[]{
+              1.0f,float.PositiveInfinity
+            };
+            return LinqExtensions.CartesianProduct(new[] { inputShapes, constShapes, clampShapes, mins, maxs }).Select(
+              p => p.ToArray());
+        }
+    }
+
+    private (Var, Expr) GetCombineClampBinaryCase(BinaryOp op, int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        Expr rootPre;
+        var input = new Var("input", new TensorType(DataTypes.Float32, inputShape));
+        {
+            var v0 = IR.F.Tensors.NCHWToNHWC(input);
+            var v1 = IR.F.Math.Binary(op, v0, Const.FromValue(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 4, constShape).Evaluate()));
+            var v2 = IR.F.Math.Clamp(v1, Tensor.FromScalar<float>(min, clampShape), Tensor.FromScalar<float>(max, clampShape));
+            rootPre = v2;
+        }
+        return (input, rootPre);
+    }
+
+    private (Var, Var, Expr) GetCombineClampBinaryNegativeCase(BinaryOp op, int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        Expr rootPre;
+        var input = new Var("input", new TensorType(DataTypes.Float32, inputShape));
+        var constInput = new Var("constInput", new TensorType(DataTypes.Float32, constShape));
+        {
+            var v0 = IR.F.Tensors.NCHWToNHWC(input);
+            var v1 = IR.F.Math.Binary(op, v0, constInput);
+            var v2 = IR.F.Math.Clamp(v1, Tensor.FromScalar<float>(min, clampShape), Tensor.FromScalar<float>(max, clampShape));
+            rootPre = v2;
+        }
+        return (input, constInput, rootPre);
+    }
+
+    [Theory]
+    [MemberData(nameof(CombineClampBinaryPositiveData))]
+    public void TestCombineClampAddPositive(int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        var caseOptions = GetPassOptions();
+        var (input, rootPre) = GetCombineClampBinaryCase(BinaryOp.Add, inputShape, constShape, clampShape, min, max);
+
+        var feedDict = new Dictionary<Var, IValue>(ReferenceEqualityComparer.Instance){
+          {input,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 2, inputShape).Evaluate()}
+        };
+
+        CompilerServices.InferenceType(rootPre);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+            new Transform.Rules.Neutral.CombineClampAdd(),
+        }, caseOptions);
+
+        Assert.NotEqual(rootPre, rootPost);
+        Assert.True(TestFixture.Comparator.Compare(CompilerServices.Evaluate(rootPre, feedDict), CompilerServices.Evaluate(rootPost, feedDict)));
+    }
+
+    [Theory]
+    [MemberData(nameof(CombineClampBinaryPositiveData))]
+    public void TestCombineClampMulPositive(int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        var caseOptions = GetPassOptions();
+        var (input, rootPre) = GetCombineClampBinaryCase(BinaryOp.Mul, inputShape, constShape, clampShape, min, max);
+
+        var feedDict = new Dictionary<Var, IValue>(ReferenceEqualityComparer.Instance){
+          {input,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, inputShape).Evaluate()}
+        };
+
+        CompilerServices.InferenceType(rootPre);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+            new Transform.Rules.Neutral.CombineClampMul(),
+        }, caseOptions);
+
+        Assert.NotEqual(rootPre, rootPost);
+        Assert.True(TestFixture.Comparator.Compare(CompilerServices.Evaluate(rootPre, feedDict), CompilerServices.Evaluate(rootPost, feedDict)));
+    }
+
+    [Theory]
+    [MemberData(nameof(CombineClampBinaryPositiveData))]
+    public void TestCombineClampAddNegative(int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        var caseOptions = GetPassOptions();
+        var (input, constInput, rootPre) = GetCombineClampBinaryNegativeCase(BinaryOp.Add, inputShape, constShape, clampShape, min, max);
+
+        var feedDict = new Dictionary<Var, IValue>(ReferenceEqualityComparer.Instance){
+          {input,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 2, inputShape).Evaluate()},
+          {constInput,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 2, constShape).Evaluate()}
+        };
+
+        CompilerServices.InferenceType(rootPre);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+            new Transform.Rules.Neutral.CombineClampAdd(),
+        }, caseOptions);
+
+        Assert.Equal(rootPre, rootPost);
+    }
+
+    [Theory]
+    [MemberData(nameof(CombineClampBinaryPositiveData))]
+    public void TestCombineClampMulNegative(int[] inputShape, int[] constShape, int[] clampShape, float min, float max)
+    {
+        var caseOptions = GetPassOptions();
+        var (input, constInput, rootPre) = GetCombineClampBinaryNegativeCase(BinaryOp.Mul, inputShape, constShape, clampShape, min, max);
+
+        var feedDict = new Dictionary<Var, IValue>(ReferenceEqualityComparer.Instance){
+          {input,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, inputShape).Evaluate()},
+          {constInput,IR.F.Random.Normal(DataTypes.Float32, 0, 1, 2, constShape).Evaluate()}
+        };
+
+        CompilerServices.InferenceType(rootPre);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+            new Transform.Rules.Neutral.CombineClampMul(),
+        }, caseOptions);
+
+        Assert.Equal(rootPre, rootPost);
+    }
+
+}

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestCombineBinary.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestCombineBinary.cs
@@ -130,7 +130,7 @@ public class UnitTestCombineBinary
 
     [Theory]
     [MemberData(nameof(CombineClampBinaryPositiveData))]
-    public void TestCombineClampMulNegative(int[] inputShape, Tensor<float> constTensor, float min, float max)
+    public void TestCombineClampMulNegative(int[] inputShape, Tensor<float> constTensor, Tensor<float> min, Tensor<float> max)
     {
         var (input, constInput, rootPre) = GetCombineClampBinaryNegativeCase(BinaryOp.Mul, inputShape, constTensor, min, max);
         _ = new Dictionary<Var, IValue>(ReferenceEqualityComparer.Instance)

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Nncase.IR;
+using Nncase.Tests.TestFixture;
+using Nncase.Transform;
+using Nncase.Transform.Rules.Neutral;
+using Xunit;
+
+namespace Nncase.Tests.Rules.NeutralTest;
+
+[AutoSetupTestMethod(InitSession = true)]
+public class UnitTestFoldConv2DMulAdd : TestClassBase
+{
+    public static TheoryData<int[], (int, int), (int, int)> FoldConv2DMulAddPositiveData = new()
+    {
+        { new[] { 1, 256, 56, 56 }, (1, 1), (0, 0) },
+        { new[] { 1, 32, 64, 64 }, (1, 1), (0, 0) },
+        { new[] { 1, 32, 56, 56 }, (3, 3), (1, 1) },
+    };
+
+    [Theory]
+    [MemberData(nameof(FoldConv2DMulAddPositiveData))]
+    public void TestPositive(int[] shape, (int, int) kernel, (int, int) pad)
+    {
+        // note shape is nchw
+        var input = new Var("input", new TensorType(DataTypes.Float32, shape));
+        Expr rootPre;
+        {
+            var v0 = input + input;
+            var v1 = v0 * Const.FromValue(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 }).Evaluate());
+            var v2 = v1 + Const.FromValue(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 }).Evaluate());
+            var v3 = IR.F.NN.Conv2D(
+                v2,
+                IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, shape[1], kernel.Item1, kernel.Item2 }).Evaluate().AsTensor(),
+                IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 },
+                new[,]
+                  {
+                    { pad.Item1, pad.Item1 },
+                    { pad.Item2, pad.Item2 },
+                  }, new[] { 1, 1 }, PadMode.Constant, 1,
+                new[] { 0.0f, 6.0f });
+            rootPre = v3;
+        }
+
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+           new FoldConv2DMulAdd(),
+           new FoldConstCall(),
+        }, new());
+
+        Dumpper.DumpIR(rootPost, "post");
+
+        var feedDict = new Dictionary<Var, IValue>()
+        {
+          { input, IR.F.Random.Normal(DataTypes.Float32, 0, 1, 4, shape).Evaluate() },
+        };
+        Assert.NotEqual(rootPre, rootPost);
+        Assert.Equal(CompilerServices.Evaluate(rootPre, feedDict), CompilerServices.Evaluate(rootPost, feedDict));
+    }
+
+    [Theory]
+    [MemberData(nameof(FoldConv2DMulAddPositiveData))]
+    public void TestNegative(int[] shape, (int, int) kernel, (int, int) pad)
+    {
+        // note shape is nchw
+        var input = new Var("input", new TensorType(DataTypes.Float32, shape));
+        Expr rootPre;
+        {
+            var v0 = input + input;
+            var v1 = v0 * IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 });
+            var v2 = v1 + IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 });
+            var v3 = IR.F.NN.Conv2D(
+                v2,
+                IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, shape[1], kernel.Item1, kernel.Item2 }).Evaluate().AsTensor(),
+                IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, new[] { 64 }).Evaluate().AsTensor(), new[] { 1, 1 },
+                new[,]
+                  {
+                    { pad.Item1, pad.Item1 },
+                    { pad.Item2, pad.Item2 },
+                  }, new[] { 1, 1 }, PadMode.Constant, 1,
+                new[] { 0.0f, 6.0f });
+            rootPre = v3;
+        }
+
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+           new FoldConv2DMulAdd(),
+           new FoldConstCall(),
+        }, new());
+
+        Assert.Equal(rootPre, rootPost);
+    }
+}

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
@@ -77,8 +77,8 @@ public class UnitTestFoldConv2DMulAdd : TestClassBase
         Expr rootPre;
         {
             var v0 = input + input;
-            var v1 = v0 * IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 });
-            var v2 = v1 + IR.F.Random.Normal(DataTypes.Float32, 0, 1, 5, new[] { 1, shape[1], 1, 1 });
+            var v1 = v0 * new Var(new TensorType(DataTypes.Float32, new[] { 1, shape[1], 1, 1 }));
+            var v2 = v1 + new Var(new TensorType(DataTypes.Float32, new[] { 1, shape[1], 1, 1 }));
             var v3 = IR.F.NN.Conv2D(
                 v2,
                 IR.F.Random.Normal(DataTypes.Float32, 0, 1, 1, new[] { 64, shape[1], kernel.Item1, kernel.Item2 }).Evaluate().AsTensor(),

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestFoldConv2DMulAdd.cs
@@ -56,7 +56,9 @@ public class UnitTestFoldConv2DMulAdd : TestClassBase
            new FoldConstCall(),
         }, new());
 
+#if DEBUG
         Dumpper.DumpIR(rootPost, "post");
+#endif
 
         var feedDict = new Dictionary<Var, IValue>()
         {

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestReluToClamp.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestReluToClamp.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Nncase.IR;
+using Nncase.Tests.TestFixture;
+using Nncase.Transform;
+using Nncase.Transform.Rules.Neutral;
+using Xunit;
+
+namespace Nncase.Tests.Rules.NeutralTest;
+
+[AutoSetupTestMethod(InitSession = true)]
+public class UnitTestReluToClamp : TestClassBase
+{
+    public static TheoryData<Nncase.IR.NN.ActivationOp, int[]> ReluToClampPositiveData = new()
+    {
+        { new IR.NN.Relu(), new[] { 1, 2, 3, 4 } },
+        { new IR.NN.Relu6(), new[] { 4, 3, 2, 1 } },
+    };
+
+    public static TheoryData<Nncase.IR.NN.ActivationOp, int[]> ReluToClampNegativeData = new()
+    {
+        { new IR.NN.LeakyRelu(), new[] { 1, 2, 3, 4 } },
+        { new IR.NN.LeakyRelu(), new[] { 4, 3, 2, 1 } },
+    };
+
+    [Theory]
+    [MemberData(nameof(ReluToClampPositiveData))]
+    public void TestPositive(Nncase.IR.NN.ActivationOp op, int[] shape)
+    {
+        var input = new Var("input", new TensorType(DataTypes.Float32, shape));
+        var rootPre = new Call(op, input);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+           new ReluToClamp(),
+           new Relu6ToClamp(),
+        }, new());
+        var feedDict = new Dictionary<Var, IValue>()
+        {
+          { input, IR.F.Random.Normal(DataTypes.Float32, 0, 1, 4, shape).Evaluate() },
+        };
+        Assert.NotEqual(rootPre, rootPost);
+        Assert.Equal(CompilerServices.Evaluate(rootPre, feedDict), CompilerServices.Evaluate(rootPost, feedDict));
+    }
+
+    [Theory]
+    [MemberData(nameof(ReluToClampNegativeData))]
+    public void TestNegative(Nncase.IR.NN.ActivationOp op, int[] shape)
+    {
+        var input = new Var("input", new TensorType(DataTypes.Float32, shape));
+        var rootPre = new Call(op, input);
+        var rootPost = CompilerServices.Rewrite(rootPre, new IRewriteRule[]
+        {
+           new ReluToClamp(),
+           new Relu6ToClamp(),
+        }, new());
+        Assert.Equal(rootPre, rootPost);
+    }
+}

--- a/src/Nncase.Transform/Rules/Neutral/CombineBinary.cs
+++ b/src/Nncase.Transform/Rules/Neutral/CombineBinary.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Nncase.Evaluator;
+using Nncase.IR;
+using Nncase.IR.Math;
+using Nncase.IR.NN;
+using Nncase.IR.Tensors;
+using Nncase.PatternMatch;
+using static Nncase.IR.F.Math;
+using static Nncase.IR.TypePatternUtility;
+using static Nncase.PatternMatch.F.Math;
+using static Nncase.PatternMatch.Utility;
+
+
+namespace Nncase.Transform.Rules.Neutral;
+
+internal static class CombineClampUtility
+{
+    public static Pattern GetInputPattern() => IsWildcard("input", x => x is not Const) with { TypePattern = HasDataType(DataTypes.Float32) };
+
+    public static Pattern GetConstPattern(string prefix) => IsTensorConst(prefix + "Const", t => t.Value.ElementType == DataTypes.Float32);
+
+    public static Pattern GetBinaryPattern(BinaryOp op, string constPrefix) => IsAlt(
+      IsBinary(op, GetInputPattern(), GetConstPattern(constPrefix)),
+      IsBinary(op, GetConstPattern(constPrefix), GetInputPattern())
+    );
+}
+
+/// <summary>
+/// clamp(add(x,addConst),min,max) => add(clamp(x,min-addConst,max-addConst),addConst)
+/// </summary>
+[RuleGenerator]
+public sealed partial class CombineClampAdd : IRewriteRule
+{
+    /// <inheritdoc/>
+    public IPattern Pattern { get; init; } = IsClamp(
+      CombineClampUtility.GetBinaryPattern(BinaryOp.Add, "add"),
+      IsTensorConst("min", t => t.Value.ElementType == DataTypes.Float32),
+      IsTensorConst("max", t => t.Value.ElementType == DataTypes.Float32));
+
+    private Expr? GetReplace(Expr input, Tensor<float> addConst, Tensor<float> min, Tensor<float> max)
+    {
+        var newType = Evaluator.TypeInference.BroadcastType(new TensorType(addConst.ElementType, addConst.Shape), new TensorType(min.ElementType, min.Shape));
+        if (newType is not TensorType newClampType || !newClampType.Shape.IsFixed)
+            return null;
+
+        var newMin = (min.ToOrtTensor() - addConst.ToOrtTensor()).ToValue();
+        var newMax = (max.ToOrtTensor() - addConst.ToOrtTensor()).ToValue();
+        return Add(Clamp(input, Const.FromValue(newMin), Const.FromValue(newMax)), addConst);
+    }
+}
+
+/// <summary>
+/// clamp(mul(x,mulConst),min,max) => mul(clamp(x,min/mulConst,max/mulConst),mulConst)
+/// </summary>
+[RuleGenerator]
+public sealed partial class CombineClampMul : IRewriteRule
+{
+    /// <inheritdoc/>
+    public IPattern Pattern { get; } = IsClamp(
+      CombineClampUtility.GetBinaryPattern(BinaryOp.Mul, "mul"),
+      IsTensorConst("min", t => t.Value.ElementType == DataTypes.Float32),
+      IsTensorConst("max", t => t.Value.ElementType == DataTypes.Float32));
+
+    private Expr? GetReplace(Expr input, Tensor<float> mulConst, Tensor<float> min, Tensor<float> max)
+    {
+        var newType = Evaluator.TypeInference.BroadcastType(new TensorType(mulConst.ElementType, mulConst.Shape), new TensorType(min.ElementType, min.Shape));
+        if (newType is not TensorType newClampType || !newClampType.Shape.IsFixed)
+            return null;
+
+        // avoid div zero.
+        if (mulConst.All(f => f == 0.0f))
+            return null;
+        var tmulConst = mulConst.ToOrtTensor();
+        var mint = min.ToOrtTensor();
+        var maxt = max.ToOrtTensor();
+        var cond = OrtKISharp.OrtKI.Less(tmulConst, OrtKISharp.Tensor.FromScalar<float>(0.0f));
+        var newMin = mint / tmulConst;
+        var newMax = maxt / tmulConst;
+        return Mul(
+          Clamp(
+            input,
+            Const.FromValue(OrtKISharp.OrtKI.Where(cond, maxt, mint).ToValue()), 
+            Const.FromValue(OrtKISharp.OrtKI.Where(cond, mint, maxt).ToValue())
+          ), 
+          mulConst
+        );
+    }
+}

--- a/src/Nncase.Transform/Rules/Neutral/CombineTranspose.cs
+++ b/src/Nncase.Transform/Rules/Neutral/CombineTranspose.cs
@@ -117,7 +117,7 @@ public sealed partial class CombineTransposeConstBinary : RewriteRule<CallPatter
       IsTranspose(
         IsAlt(
           IsBinary("binary", _ => true, IsWildcard("x", x => x is not Const), IsTensorConst("y")),
-          IsBinary("binary", _ => true, IsTensorConst("y"), IsWildcard("x", x => x is not Const))),
+          IsBinary("binary", _ => true, IsTensorConst("x"), IsWildcard("y", x => x is not Const))),
         IsTensorConst("perm"));
 
     private Const GetNewConst(TensorConst oldConst, Expr input, TensorConst perm)
@@ -142,12 +142,9 @@ public sealed partial class CombineTransposeConstBinary : RewriteRule<CallPatter
         {
             return Binary(binary.BinaryOp, GetNewConst(constX, y, perm), Transpose(y, perm));
         }
-        else if (y is TensorConst constY)
-        {
-            return Binary(binary.BinaryOp, Transpose(x, perm), GetNewConst(constY, x, perm));
-        }
 
-        return null;
+        var constY = (TensorConst)y;
+        return Binary(binary.BinaryOp, Transpose(x, perm), GetNewConst(constY, x, perm));
     }
 }
 

--- a/src/Nncase.Transform/Rules/Neutral/ReluToClamp.cs
+++ b/src/Nncase.Transform/Rules/Neutral/ReluToClamp.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Canaan Inc. All rights reserved.
+﻿// Copyright (c) Canaan Inc. All rights reserved.
 // Licensed under the Apache license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Nncase.PatternMatch;
 using static Nncase.IR.F.Math;
 using static Nncase.IR.TypePatternUtility;
 using static Nncase.PatternMatch.F.Math;
+using static Nncase.PatternMatch.F.NN;
 using static Nncase.PatternMatch.Utility;
 
 namespace Nncase.Transform.Rules.Neutral;
@@ -20,10 +21,10 @@ namespace Nncase.Transform.Rules.Neutral;
 /// convert <see cref="IR.NN.Relu"/> to <see cref="IR.Math.Clamp"/>.
 /// </summary>
 [RuleGenerator]
-public sealed partial class ReluToClamp : IRewriteRule
+public sealed partial class ReluToClamp : RewriteRule<CallPattern>
 {
     /// <inheritdoc/>
-    public IPattern Pattern { get; } = IsRelu(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
+    public override CallPattern Pattern { get; } = IsRelu(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
 
     private Expr? GetReplace(Expr input)
     {
@@ -35,10 +36,10 @@ public sealed partial class ReluToClamp : IRewriteRule
 /// convert <see cref="IR.NN.Relu6"/> to <see cref="IR.Math.Clamp"/>.
 /// </summary>
 [RuleGenerator]
-public sealed partial class Relu6ToClamp : IRewriteRule
+public sealed partial class Relu6ToClamp : RewriteRule<CallPattern>
 {
     /// <inheritdoc/>
-    public IPattern Pattern { get; } = IsRelu6(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
+    public override CallPattern Pattern { get; } = IsRelu6(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
 
     private Expr? GetReplace(Expr input)
     {

--- a/src/Nncase.Transform/Rules/Neutral/ReluToClamp.cs
+++ b/src/Nncase.Transform/Rules/Neutral/ReluToClamp.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Nncase.IR;
+using Nncase.IR.Math;
+using Nncase.IR.Tensors;
+using Nncase.PatternMatch;
+using static Nncase.IR.F.Math;
+using static Nncase.IR.TypePatternUtility;
+using static Nncase.PatternMatch.F.Math;
+using static Nncase.PatternMatch.Utility;
+
+namespace Nncase.Transform.Rules.Neutral;
+
+/// <summary>
+/// convert <see cref="IR.NN.Relu"/> to <see cref="IR.Math.Clamp"/>.
+/// </summary>
+[RuleGenerator]
+public sealed partial class ReluToClamp : IRewriteRule
+{
+    /// <inheritdoc/>
+    public IPattern Pattern { get; } = IsRelu(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
+
+    private Expr? GetReplace(Expr input)
+    {
+        return Clamp(input, 0.0f, float.PositiveInfinity);
+    }
+}
+
+/// <summary>
+/// convert <see cref="IR.NN.Relu6"/> to <see cref="IR.Math.Clamp"/>.
+/// </summary>
+[RuleGenerator]
+public sealed partial class Relu6ToClamp : IRewriteRule
+{
+    /// <inheritdoc/>
+    public IPattern Pattern { get; } = IsRelu6(IsWildcard("input") with { TypePattern = HasDataType(DataTypes.Float32) });
+
+    private Expr? GetReplace(Expr input)
+    {
+        return Clamp(input, 0.0f, 6.0f);
+    }
+}

--- a/tools/stackvm_gen/IsaGen/Program.cs
+++ b/tools/stackvm_gen/IsaGen/Program.cs
@@ -343,7 +343,7 @@ namespace IsaGen
                 return CppFieldType(f.PropertyType) + "::" + v.ToString();
             }
 
-            return v.ToString();
+            return v.ToString()!;
         }
 
         private uint FieldLength(Type t)


### PR DESCRIPTION
- [x] Add fold conv2D+BatchNorm (first convert Relu to Clamp, then combine Clamp with Binary, finally fold Conv2D+BN)
   - [x] Add ReluToClamp,Relu6ToClamp
   - [x] Add CombineClampMul/CombineClampAdd
   - [x] add FoldConv2DMulAdd
- [x] Add dumpFlags parameter in DumpScope ctor, Now the Dumpflag of the subdumper can be modified.
```csharp
        // Can custom dump information in the tests.
        using (var _ = new DumpScope($"Eval", DumpFlags.Evaluator)){
            CompilerServices.Evaluate(expr);
        }
```

I suggest to name CombineRule according to the order of Call. For example:
`Transpose(Pad(x)) => Pad(Transpose(x))`, should be named `CombineTransposePad`.