### PR TITLE
Make mutators public

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
     <PackageVersion Include="Nncase.FlatBuffers" Version="2.0.0" />
     <PackageVersion Include="OrtKISharp" Version="0.0.2" />
-    <PackageVersion Include="RazorLight" Version="2.0.0-rc.2" />
+    <PackageVersion Include="RazorLight" Version="2.3.0" />
     <PackageVersion Include="Singulink.Collections.Weak" Version="1.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />

--- a/src/Nncase.Core/IR/TypePattern.cs
+++ b/src/Nncase.Core/IR/TypePattern.cs
@@ -175,7 +175,7 @@ namespace Nncase.IR
         /// </summary>
         /// <returns></returns>
         public static TypePattern IsPointer() => new TypePattern(
-          x => x is TensorType { IsScalar: true, DType: PointerType { ElemType: PrimType { } } }, "IsPointer");
+          x => x is TensorType { IsScalar: true, DType: PointerType }, "IsPointer");
 
         /// <summary>
         /// check the datatype is scalar.

--- a/src/Nncase.Core/Transform/Mutators/ConvertBlocksToOpaque.cs
+++ b/src/Nncase.Core/Transform/Mutators/ConvertBlocksToOpaque.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// Substitute all the block vars with the PrimExprs they are bound to, indicated by the corresponding iter_values in BlockRealize, for opaque blocks by removing all . the iter_values in BlockRealize and iter_vars in Block.
 /// </summary>
-internal sealed class ConvertBlocksToOpaque : ExprMutator
+public sealed class ConvertBlocksToOpaque : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(IterVar expr)

--- a/src/Nncase.Core/Transform/Mutators/FlattenBuffer.cs
+++ b/src/Nncase.Core/Transform/Mutators/FlattenBuffer.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// Flatten the multi-dimensional BufferLoad and BufferStore to single dimensional Load/Store. Also remove Block to ensure that the flattened TIR can not be scheduled again.
 /// </summary>
-internal sealed class FlattenBuffer : ExprMutator
+public sealed class FlattenBuffer : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(Block expr)

--- a/src/Nncase.Core/Transform/Mutators/FlattenSequential.cs
+++ b/src/Nncase.Core/Transform/Mutators/FlattenSequential.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// flatten sequential.
 /// </summary>
-internal sealed class FlattenSequential : ExprMutator
+public sealed class FlattenSequential : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(TIR.Sequential expr)

--- a/src/Nncase.Core/Transform/Mutators/FoldConstTuple.cs
+++ b/src/Nncase.Core/Transform/Mutators/FoldConstTuple.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// unroll loop.
 /// </summary>
-internal sealed class FoldConstTuple : ExprMutator
+public sealed class FoldConstTuple : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(IR.Tuple expr)

--- a/src/Nncase.Core/Transform/Mutators/FoldIfThen.cs
+++ b/src/Nncase.Core/Transform/Mutators/FoldIfThen.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// fold if then and select.
 /// </summary>
-internal sealed class FoldIfThen : ExprMutator
+public sealed class FoldIfThen : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(TIR.IfThenElse expr)

--- a/src/Nncase.Core/Transform/Mutators/FoldLet.cs
+++ b/src/Nncase.Core/Transform/Mutators/FoldLet.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// unroll loop.
 /// </summary>
-internal sealed class FoldLet : ExprMutator
+public sealed class FoldLet : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(TIR.Let expr)

--- a/src/Nncase.Core/Transform/Mutators/FoldMathCall.cs
+++ b/src/Nncase.Core/Transform/Mutators/FoldMathCall.cs
@@ -10,7 +10,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// fold math calc operator.
 /// </summary>
-internal sealed class FoldMathCall : ExprMutator
+public sealed class FoldMathCall : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(Call expr)

--- a/src/Nncase.Core/Transform/Mutators/LowerBlockInit.cs
+++ b/src/Nncase.Core/Transform/Mutators/LowerBlockInit.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// Flatten the multi-dimensional BufferLoad and BufferStore to single dimensional Load/Store. Also remove Block to ensure that the flattened TIR can not be scheduled again.
 /// </summary>
-internal sealed class LowerBlockInit : ExprMutator
+public sealed class LowerBlockInit : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr VisitLeaf(Block expr)

--- a/src/Nncase.Core/Transform/Mutators/RemoveNop.cs
+++ b/src/Nncase.Core/Transform/Mutators/RemoveNop.cs
@@ -10,7 +10,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// remove the nop call from the body.
 /// </summary>
-internal sealed class RemoveNop : ExprMutator
+public sealed class RemoveNop : ExprMutator
 {
     public override Expr MutateLeaf(TIR.Sequential expr)
     {

--- a/src/Nncase.Core/Transform/Mutators/SubstituteVarAndCollectOpaqueBlock.cs
+++ b/src/Nncase.Core/Transform/Mutators/SubstituteVarAndCollectOpaqueBlock.cs
@@ -12,7 +12,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// Substitute vars and collect the reuse mapping of opaque blocks.
 /// </summary>
-internal sealed class SubstituteVarAndCollectOpaqueBlock : ExprMutator
+public sealed class SubstituteVarAndCollectOpaqueBlock : ExprMutator
 {
     private readonly Func<Var, Expr?> _varMaper;
     private readonly Dictionary<Block, Block> _opaqueBlocks;

--- a/src/Nncase.Core/Transform/Mutators/Substitutor.cs
+++ b/src/Nncase.Core/Transform/Mutators/Substitutor.cs
@@ -15,7 +15,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// substitutor will not substitute the other function.
 /// </summary>
-internal sealed class Substitutor : ExprMutator
+public sealed class Substitutor : ExprMutator
 {
     private readonly Func<Expr, Expr?> _maper;
 

--- a/src/Nncase.Core/Transform/Mutators/UnFoldBlock.cs
+++ b/src/Nncase.Core/Transform/Mutators/UnFoldBlock.cs
@@ -13,7 +13,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// unroll loop.
 /// </summary>
-internal sealed class UnFoldBlock : ExprMutator
+public sealed class UnFoldBlock : ExprMutator
 {
     /// <inheritdoc/>
     public override Expr MutateLeaf(TIR.Block expr)

--- a/src/Nncase.Core/Transform/Mutators/UnrollLoop.cs
+++ b/src/Nncase.Core/Transform/Mutators/UnrollLoop.cs
@@ -14,7 +14,7 @@ namespace Nncase.Transform.Mutators;
 /// <summary>
 /// unroll loop.
 /// </summary>
-internal sealed class UnRollLoop : ExprMutator
+public sealed class UnRollLoop : ExprMutator
 {
     private readonly Dictionary<Type, Evaluator.IEvaluator> _evaluator_cache = new();
 

--- a/src/Nncase.Core/Transform/RulesPass.cs
+++ b/src/Nncase.Core/Transform/RulesPass.cs
@@ -20,8 +20,8 @@ public interface IRulesAddable
     /// <summary>
     /// Add the rewrite rule.
     /// </summary>
-    /// <typeparam name="T">Rule type.</typeparam>
-    /// <param name="parameters">Rule's constructor parameters.</param>
+    /// <typeparam name="T">Descriptor type.</typeparam>
+    /// <param name="parameters">Descriptor's constructor parameters.</param>
     /// <returns>Add result.</returns>
     RulesPass.AddResult<T> Add<T>(params object[] parameters)
         where T : class, IRewriteRule;
@@ -29,8 +29,8 @@ public interface IRulesAddable
     /// <summary>
     /// Add the rewrite rule.
     /// </summary>
-    /// <param name="ruleType">Rule type.</param>
-    /// <param name="parameters">Rule's constructor parameters.</param>
+    /// <param name="ruleType">Descriptor type.</param>
+    /// <param name="parameters">Descriptor's constructor parameters.</param>
     /// <returns>Add result.</returns>
     RulesPass.AddResult<IRewriteRule> Add(Type ruleType, params object[] parameters);
 }
@@ -69,7 +69,7 @@ public abstract class RulesPass : FunctionPass, IRulesAddable
     /// <summary>
     /// Add rule result.
     /// </summary>
-    /// <typeparam name="T">Pass type.</typeparam>
+    /// <typeparam name="T">Descriptor type.</typeparam>
     public struct AddResult<T> : IRulesAddable
         where T : class, IRewriteRule
     {

--- a/src/Nncase.Tests.TestFixture/TestingServices.cs
+++ b/src/Nncase.Tests.TestFixture/TestingServices.cs
@@ -220,6 +220,7 @@ public static class Testing
         var modelBuilder = compileSession.GetRequiredService<IModelBuilder>();
         var linkedModel = modelBuilder.Build(module);
 
+        Directory.CreateDirectory(compileSession.CompileOptions.DumpDir);
         var kmodel_path = Path.Combine(compileSession.CompileOptions.DumpDir, $"{name}.kmodel");
         using (var output = System.IO.File.Open(kmodel_path, System.IO.FileMode.Create))
         {

--- a/src/Nncase.Tests.TestFixture/TransformTestBase.cs
+++ b/src/Nncase.Tests.TestFixture/TransformTestBase.cs
@@ -27,26 +27,26 @@ public partial class TransformTestBase : TestClassBase
         CompileOptions.QuantizeOptions.WQuantType = DataTypes.UInt8;
     }
 
-    public virtual Expr TestMatched<T>(Expr pre, RunPassContext passOptions)
+    public virtual Expr TestMatched<T>(Expr pre)
         where T : IRewriteRule, new()
     {
-        return TestMatchedCore(pre, passOptions, new T());
+        return TestMatchedCore(pre, new T());
     }
 
-    public void CondMatch<T>(bool cond, Expr expr, RunPassContext passOptions)
+    public void CondMatch<T>(bool cond, Expr expr)
         where T : IRewriteRule, new()
     {
         if (cond)
         {
-            TestMatched<T>(expr, passOptions);
+            TestMatched<T>(expr);
         }
         else
         {
-            TestNotMatch<T>(expr, passOptions);
+            TestNotMatch<T>(expr);
         }
     }
 
-    public Expr TestMatchedCore(Expr pre, RunPassContext passOptions, params IRewriteRule[] rules)
+    public Expr TestMatchedCore(Expr pre, params IRewriteRule[] rules)
     {
         Assert.True(pre.InferenceType(), "TestInferFailed:" + pre.CheckedType);
         if (rules.Length == 0)
@@ -54,7 +54,7 @@ public partial class TransformTestBase : TestClassBase
             throw new InvalidOperationException("Rules should not be empty");
         }
 
-        var post = CompilerServices.Rewrite(pre, rules, passOptions);
+        var post = CompilerServices.Rewrite(pre, rules, new());
         Assert.NotEqual(pre, post);
         var v1 = pre.Evaluate();
         var v2 = post.Evaluate();
@@ -63,17 +63,17 @@ public partial class TransformTestBase : TestClassBase
         return post;
     }
 
-    public void TestNotMatch(Expr pre, RunPassContext passOptions, params IRewriteRule[] rules)
+    public void TestNotMatch(Expr pre, params IRewriteRule[] rules)
     {
         pre.InferenceType();
-        var post = CompilerServices.Rewrite(pre, rules, passOptions);
+        var post = CompilerServices.Rewrite(pre, rules, new());
         Assert.Equal(pre, post);
     }
 
-    public void TestNotMatch<T>(Expr pre, RunPassContext passOptions)
+    public void TestNotMatch<T>(Expr pre)
         where T : IRewriteRule, new()
     {
-        TestNotMatch(pre, passOptions, new T());
+        TestNotMatch(pre, new T());
     }
 
     // public void TestSwappableBinary<T>(BinaryOp op, Expr lhs, Expr rhs) where T : IRewriteRule, new()
@@ -117,21 +117,21 @@ public partial class TransformTestBase : TestClassBase
             new FoldNopCast(),
         }, fuse);
 
-    public Expr TestMultiMatched<T>(Expr expr, RunPassContext passOptions, int count)
+    public Expr TestMultiMatched<T>(Expr expr, int count)
         where T : IRewriteRule, new()
         =>
         Enumerable.Range(0, count).Aggregate(expr, (expr1, i) =>
         {
-            var ex = TestMatched<T>(expr1, passOptions);
+            var ex = TestMatched<T>(expr1);
             return ex;
         });
 
-    public Expr RewriteMultiTimes<T>(Expr expr, RunPassContext passOptions, int count)
+    public Expr RewriteMultiTimes<T>(Expr expr, int count)
         where T : IRewriteRule, new()
         =>
         Enumerable.Range(0, count).Aggregate(expr, (expr1, i) =>
         {
-            var ex = Rewrite<T>(expr1, passOptions);
+            var ex = Rewrite<T>(expr1, new());
             return ex;
         });
 


### PR DESCRIPTION
- Add mutators to `PrimFuncPass` need types of mutators. It requires to make mutators public.
- Allow `IsPointer` pattern accept all types (before `PrimType` only)