### PR TITLE
Fix egraph marker cost evaluator

### DIFF
--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -76,16 +76,6 @@ internal class Compiler : ICompiler
                 p.Add<Transform.Rules.Neutral.FoldConv2DPads>();
                 p.Add<Transform.Rules.Neutral.FoldReduceWindow2DPads>();
             });
-            passManager.AddWithName<EGraphPass>("NeutralOptimizeClamp").Configure(p =>
-            {
-                p.Add<Transform.Rules.Neutral.FoldConstCall>();
-                p.Add<Transform.Rules.Neutral.FoldConv2DAddMul>();
-                p.Add<Transform.Rules.Neutral.ReluToClamp>();
-                p.Add<Transform.Rules.Neutral.Relu6ToClamp>();
-                p.Add<Transform.Rules.Neutral.CombineClampAdd>();
-                p.Add<Transform.Rules.Neutral.CombineClampMul>();
-                p.Add<Transform.Rules.Neutral.FoldNopClamp>();
-            });
         }
 
         if (quantMode == ModelQuantMode.UsePTQ)
@@ -104,21 +94,21 @@ internal class Compiler : ICompiler
         await RunPassAsync(p => TargetIndependentPass(p), "TargetIndependentPass");
         await RunPassAsync(p => target.RegisterTargetDependentPass(p, _compileSession.CompileOptions), "TargetDependentPass");
 
-        if (_compileSession.CompileOptions.QuantizeOptions.ModelQuantMode == ModelQuantMode.UsePTQ)
-        {
-            await RunPassAsync(p => target.RegisterQuantizePass(p, _compileSession.CompileOptions), "QuantizePass");
-            await RunPassAsync(p => target.RegisterTargetDependentAfterQuantPass(p, _compileSession.CompileOptions), "TargetDependentAfterQuantPass");
-            await RunPassAsync(
-                pmgr => pmgr.Add<DataflowPass>().Configure(p =>
-                {
-                    p.Name = "ClearMarker";
-                    p.Add<RemoveMarker>();
-                }),
-                "RemoveMarker");
-        }
+        // if (_compileSession.CompileOptions.QuantizeOptions.ModelQuantMode == ModelQuantMode.UsePTQ)
+        // {
+        //     await RunPassAsync(p => target.RegisterQuantizePass(p, _compileSession.CompileOptions), "QuantizePass");
+        //     await RunPassAsync(p => target.RegisterTargetDependentAfterQuantPass(p, _compileSession.CompileOptions), "TargetDependentAfterQuantPass");
+        //     await RunPassAsync(
+        //         pmgr => pmgr.Add<DataflowPass>().Configure(p =>
+        //         {
+        //             p.Name = "ClearMarker";
+        //             p.Add<RemoveMarker>();
+        //         }),
+        //         "RemoveMarker");
+        // }
 
-        // fold constant
-        await RunPassAsync(p => p.Add<ShapeInferPass>(), "ShapeInferAfterCompile");
+        // // fold constant
+        // await RunPassAsync(p => p.Add<ShapeInferPass>(), "ShapeInferAfterCompile");
     }
 
     public void Gencode(Stream output)

--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -76,6 +76,16 @@ internal class Compiler : ICompiler
                 p.Add<Transform.Rules.Neutral.FoldConv2DPads>();
                 p.Add<Transform.Rules.Neutral.FoldReduceWindow2DPads>();
             });
+            passManager.AddWithName<EGraphPass>("NeutralOptimizeClamp").Configure(p =>
+            {
+                p.Add<Transform.Rules.Neutral.FoldConstCall>();
+                p.Add<Transform.Rules.Neutral.FoldConv2DAddMul>();
+                p.Add<Transform.Rules.Neutral.ReluToClamp>();
+                p.Add<Transform.Rules.Neutral.Relu6ToClamp>();
+                p.Add<Transform.Rules.Neutral.CombineClampAdd>();
+                p.Add<Transform.Rules.Neutral.CombineClampMul>();
+                p.Add<Transform.Rules.Neutral.FoldNopClamp>();
+            });
         }
 
         if (quantMode == ModelQuantMode.UsePTQ)
@@ -94,21 +104,21 @@ internal class Compiler : ICompiler
         await RunPassAsync(p => TargetIndependentPass(p), "TargetIndependentPass");
         await RunPassAsync(p => target.RegisterTargetDependentPass(p, _compileSession.CompileOptions), "TargetDependentPass");
 
-        // if (_compileSession.CompileOptions.QuantizeOptions.ModelQuantMode == ModelQuantMode.UsePTQ)
-        // {
-        //     await RunPassAsync(p => target.RegisterQuantizePass(p, _compileSession.CompileOptions), "QuantizePass");
-        //     await RunPassAsync(p => target.RegisterTargetDependentAfterQuantPass(p, _compileSession.CompileOptions), "TargetDependentAfterQuantPass");
-        //     await RunPassAsync(
-        //         pmgr => pmgr.Add<DataflowPass>().Configure(p =>
-        //         {
-        //             p.Name = "ClearMarker";
-        //             p.Add<RemoveMarker>();
-        //         }),
-        //         "RemoveMarker");
-        // }
+        if (_compileSession.CompileOptions.QuantizeOptions.ModelQuantMode == ModelQuantMode.UsePTQ)
+        {
+            await RunPassAsync(p => target.RegisterQuantizePass(p, _compileSession.CompileOptions), "QuantizePass");
+            await RunPassAsync(p => target.RegisterTargetDependentAfterQuantPass(p, _compileSession.CompileOptions), "TargetDependentAfterQuantPass");
+            await RunPassAsync(
+                pmgr => pmgr.Add<DataflowPass>().Configure(p =>
+                {
+                    p.Name = "ClearMarker";
+                    p.Add<RemoveMarker>();
+                }),
+                "RemoveMarker");
+        }
 
-        // // fold constant
-        // await RunPassAsync(p => p.Add<ShapeInferPass>(), "ShapeInferAfterCompile");
+        // fold constant
+        await RunPassAsync(p => p.Add<ShapeInferPass>(), "ShapeInferAfterCompile");
     }
 
     public void Gencode(Stream output)

--- a/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
@@ -137,10 +137,10 @@ internal sealed class EGraphCostEvaluator
 
     private Cost? Visit(ENode enode, Marker marker)
     {
-        return Visit(enode, costs => Cost.Zero);
+        return Visit(enode, costs => costs[0]);
     }
 
-    private Cost? Visit(ENode enode, None marker)
+    private Cost? Visit(ENode enode, None none)
     {
         return Visit(enode, costs => Cost.Zero);
     }

--- a/src/Nncase.Tests/Rewrite/UnitTestEGraphRewrite.cs
+++ b/src/Nncase.Tests/Rewrite/UnitTestEGraphRewrite.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Threading.Tasks;
 using Nncase.CostModel;
 using Nncase.Evaluator;
 using Nncase.IR;
@@ -15,6 +16,7 @@ using static Nncase.PatternMatch.Utility;
 
 namespace Nncase.Tests.ReWriteTest;
 
+[AutoSetupTestMethod(InitSession = true)]
 public class UnitTestEGraphRewrite : TestClassBase
 {
     [Fact]
@@ -112,6 +114,34 @@ public class UnitTestEGraphRewrite : TestClassBase
           post is Marker { Target: Call { Parameters: IRArray<Expr> param } } &&
           param.Count == 2 &&
           param[1] is Marker);
+    }
+
+    [Fact]
+    public async Task TestEgraphRemoveMarkerPreserveCosts()
+    {
+#if DEBUG
+        CompileOptions.DumpFlags = Diagnostics.DumpFlags.Rewrite | Diagnostics.DumpFlags.EGraphCost;
+#endif
+        var v8 = new Var("input", new TensorType(DataTypes.Float32, new[] { 1, 64, 56, 56 }));
+        var v9 = IR.F.NN.Conv2D(v8, Testing.Rand<float>(64, 64, 1, 1), Testing.Rand<float>(64), new[] { 1, 1 }, new[,] { { 0, 0 }, { 0, 0 } }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { float.NegativeInfinity, float.PositiveInfinity });
+        var v10 = IR.F.Math.RangeOfMarker(v9, new[] { -9.914007, 38.64287 }); // f32[1,56,56,64]
+        var v11 = IR.F.NN.Conv2D(v10, Testing.Rand<float>(64, 64, 1, 1), Testing.Rand<float>(64), new[] { 1, 1 }, new[,] { { 0, 0 }, { 0, 0 } }, new[] { 1, 1 }, PadMode.Constant, 1, new[] { float.NegativeInfinity, float.PositiveInfinity });
+        var v12 = IR.F.Math.RangeOfMarker(v11, new[] { -14.803145, 40.543793 }); // f32[1,64,56,56]
+        var v13 = IR.F.NN.Relu(v12); // f32[1,64,56,56]
+        var func = new Function("main", v13, new[] { v8 });
+        var module = new IRModule(func);
+
+        var passes = CompileSession.CreatePassManager("passes");
+        passes.AddWithName<EGraphPass>("Opt").Configure(p =>
+        {
+            p.Add<Transform.Rules.Lower.RemoveMarker>();
+            p.Add<Transform.Rules.Neutral.ReluToClamp>();
+            p.Add<Transform.Rules.Neutral.FuseClampConv2D>();
+        });
+
+        await passes.RunAsync(module);
+        var post = (Function)module.Entry!;
+        Assert.True(post.Body is Call { Target: IR.NN.Conv2D });
     }
 }
 

--- a/src/Nncase.Transform/Rules/Neutral/FuseClampConv2D.cs
+++ b/src/Nncase.Transform/Rules/Neutral/FuseClampConv2D.cs
@@ -1,3 +1,6 @@
+﻿// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using Nncase.IR;
 using Nncase.IR.NN;
@@ -9,11 +12,11 @@ using static Nncase.Utilities.ReplaceUtility;
 namespace Nncase.Transform.Rules.Neutral;
 
 /// <summary>
-///     
-///         Conv2d               
+///
+///         Conv2d
 ///           |            =>   Conv2d
-///          clamp         
-/// 
+///          clamp.
+///
 /// </summary>
 [RuleGenerator]
 public sealed partial class FuseClampConv2D : RewriteRule<Pattern>
@@ -23,8 +26,7 @@ public sealed partial class FuseClampConv2D : RewriteRule<Pattern>
       IsClamp(
         IsCallSpecific("call", IsOp<Conv2D>("op"), (Conv2D.FusedClamp, IsTensorConst("fusedClamp"))),
         IsTensorConst("min", t => t.Value.Shape.IsScalar && t.Value.ElementType == DataTypes.Float32),
-        IsTensorConst("max", t => t.Value.Shape.IsScalar && t.Value.ElementType == DataTypes.Float32)
-      );
+        IsTensorConst("max", t => t.Value.Shape.IsScalar && t.Value.ElementType == DataTypes.Float32));
 
     private Expr? GetReplace(Op op, IReadOnlyList<Expr> callParams, float[] fusedClamp, float min, float max)
     {

--- a/src/Nncase.Transform/Rules/Neutral/FuseClampConv2D.cs
+++ b/src/Nncase.Transform/Rules/Neutral/FuseClampConv2D.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Nncase.IR;
+using Nncase.IR.NN;
+using Nncase.PatternMatch;
+using static Nncase.PatternMatch.F.Math;
+using static Nncase.PatternMatch.Utility;
+using static Nncase.Utilities.ReplaceUtility;
+
+namespace Nncase.Transform.Rules.Neutral;
+
+/// <summary>
+///     
+///         Conv2d               
+///           |            =>   Conv2d
+///          clamp         
+/// 
+/// </summary>
+[RuleGenerator]
+public sealed partial class FuseClampConv2D : RewriteRule<Pattern>
+{
+    /// <inheritdoc/>
+    public override Pattern Pattern { get; } =
+      IsClamp(
+        IsCallSpecific("call", IsOp<Conv2D>("op"), (Conv2D.FusedClamp, IsTensorConst("fusedClamp"))),
+        IsTensorConst("min", t => t.Value.Shape.IsScalar && t.Value.ElementType == DataTypes.Float32),
+        IsTensorConst("max", t => t.Value.Shape.IsScalar && t.Value.ElementType == DataTypes.Float32)
+      );
+
+    private Expr? GetReplace(Op op, IReadOnlyList<Expr> callParams, float[] fusedClamp, float min, float max)
+    {
+        var newClamp = new float[2];
+        newClamp[0] = System.MathF.Max(min, fusedClamp[0]);
+        newClamp[1] = System.MathF.Min(max, fusedClamp[1]);
+        return ReplaceCallParams(op, callParams, (Conv2D.FusedClamp, newClamp));
+    }
+}


### PR DESCRIPTION
The EGraph cost evaluator marker cost getter will return `Costs.Zero`, it will affect the accumulation of cost.

Eg. we fuse the `FakeActivations` and `Relu`, but the `Relu` cost equal to fused `FakeActivations`, finally the non-optimal graph will be extracted.
<img width="1241" alt="截屏2023-01-31 13 15 53" src="https://user-images.githubusercontent.com/26156999/215672460-964ea17b-2caa-40e7-a7d5-e44a0cfc85b8.png">

when fix the marker cost getter, it can extract the optimal graph.
<img width="1040" alt="截屏2023-01-31 13 16 12" src="https://user-images.githubusercontent.com/26156999/215672467-522aee58-5e47-454f-99f0-dd5d8f8c7173.png">
