### PR TITLE
fix function body add marker

### DIFF
--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -76,6 +76,7 @@ internal class Compiler : ICompiler
                 p.Add<Transform.Rules.Neutral.FoldConv2DPads>();
                 p.Add<Transform.Rules.Neutral.FoldReduceWindow2DPads>();
             });
+
             // passManager.AddWithName<EGraphPass>("NeutralOptimizeClamp").Configure(p =>
             // {
             //     p.Add<Transform.Rules.Neutral.FoldConstCall>();

--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -94,7 +94,6 @@ internal class Compiler : ICompiler
             passManager.AddWithName<DataflowPass>("AddRangeOfMarker").Configure(p =>
             {
                 p.Add<Transform.Rules.Neutral.AddRangeOfAndMarker>();
-                p.Add<Transform.Rules.Neutral.AddRangeOfAndMarkerOnFuncBody>();
             });
             passManager.AddWithName<EGraphPassWithQuantize>("AssignRanges");
         }

--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -94,7 +94,7 @@ internal class Compiler : ICompiler
             passManager.AddWithName<DataflowPass>("AddRangeOfMarker").Configure(p =>
             {
                 p.Add<Transform.Rules.Neutral.AddRangeOfAndMarker>();
-                p.Add<Transform.Rules.Neutral.AddRangeOfAndMarkerOnFunction>();
+                p.Add<Transform.Rules.Neutral.AddRangeOfAndMarkerOnFuncBody>();
             });
             passManager.AddWithName<EGraphPassWithQuantize>("AssignRanges");
         }

--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -76,16 +76,16 @@ internal class Compiler : ICompiler
                 p.Add<Transform.Rules.Neutral.FoldConv2DPads>();
                 p.Add<Transform.Rules.Neutral.FoldReduceWindow2DPads>();
             });
-            passManager.AddWithName<EGraphPass>("NeutralOptimizeClamp").Configure(p =>
-            {
-                p.Add<Transform.Rules.Neutral.FoldConstCall>();
-                p.Add<Transform.Rules.Neutral.FoldConv2DAddMul>();
-                p.Add<Transform.Rules.Neutral.ReluToClamp>();
-                p.Add<Transform.Rules.Neutral.Relu6ToClamp>();
-                p.Add<Transform.Rules.Neutral.CombineClampAdd>();
-                p.Add<Transform.Rules.Neutral.CombineClampMul>();
-                p.Add<Transform.Rules.Neutral.FoldNopClamp>();
-            });
+            // passManager.AddWithName<EGraphPass>("NeutralOptimizeClamp").Configure(p =>
+            // {
+            //     p.Add<Transform.Rules.Neutral.FoldConstCall>();
+            //     p.Add<Transform.Rules.Neutral.FoldConv2DAddMul>();
+            //     p.Add<Transform.Rules.Neutral.ReluToClamp>();
+            //     p.Add<Transform.Rules.Neutral.Relu6ToClamp>();
+            //     p.Add<Transform.Rules.Neutral.CombineClampAdd>();
+            //     p.Add<Transform.Rules.Neutral.CombineClampMul>();
+            //     p.Add<Transform.Rules.Neutral.FoldNopClamp>();
+            // });
         }
 
         if (quantMode == ModelQuantMode.UsePTQ)
@@ -93,6 +93,7 @@ internal class Compiler : ICompiler
             passManager.AddWithName<DataflowPass>("AddRangeOfMarker").Configure(p =>
             {
                 p.Add<Transform.Rules.Neutral.AddRangeOfAndMarker>();
+                p.Add<Transform.Rules.Neutral.AddRangeOfAndMarkerOnFunction>();
             });
             passManager.AddWithName<EGraphPassWithQuantize>("AssignRanges");
         }

--- a/src/Nncase.Core/IR/Tuple.cs
+++ b/src/Nncase.Core/IR/Tuple.cs
@@ -27,7 +27,7 @@ public sealed record Tuple(IRArray<Expr> Fields) : Expr, ITuple
     }
 
     public Tuple(IEnumerable<Expr> fields)
-        : this(fields.ToArray())
+        : this(ImmutableArray.CreateRange(fields))
     {
     }
 

--- a/src/Nncase.EGraph/CostModel/EGraphCostPrinter.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostPrinter.cs
@@ -37,7 +37,7 @@ public partial class EGraphPrinter
         // 1. display each enode costs.
         foreach (var (enode, (dotnode, table)) in NodesMap)
         {
-            if (enode.Expr is IR.Var or IR.Op or IR.Marker or IR.None)
+            if (enode.Expr is IR.Var or IR.Op or IR.None)
             {
                 continue;
             }

--- a/src/Nncase.Tests/Rules/Neutral/UnitTestAddMarker.cs
+++ b/src/Nncase.Tests/Rules/Neutral/UnitTestAddMarker.cs
@@ -73,17 +73,55 @@ public class UnitTestAddMarker : TestClassBase
 #if DEBUG
         CompileOptions.DumpFlags = Diagnostics.DumpFlags.Rewrite | Diagnostics.DumpFlags.EGraphCost;
 #endif
+        var v121 = new IR.Var("a", new IR.TensorType(DataTypes.Float32, new[] { 1, 2048, 7, 7 }));
+        IR.Function main;
+        {
+            var v122 = IR.F.Tensors.Transpose(v121, new[] { 0, 2, 3, 1 }); // f32[1,7,7,2048]
+            var v123 = IR.F.Math.Mul(v122, Testing.Rand<float>(2048)); // f32[1,7,7,2048]
+            var v124 = IR.F.Math.Add(v123, Testing.Rand<float>(2048)); // f32[1,7,7,2048]
+            var v125 = IR.F.NN.Relu(v124); // f32[1,7,7,2048]
+            var v126 = new IR.Tuple(new IR.Expr[] { v125 }); // (f32[1,7,7,2048])
+            main = new IR.Function(v126, new[] { v121 });
+        }
+
+        var module = new IR.IRModule(main);
+        await TestAddMarkerPasses(module);
+        Assert.True(((IR.Function)module.Entry!).Body is IR.Tuple tuple && tuple.Fields[0] is IR.Marker);
+    }
+
+    [Fact]
+    public async Task TestAddMarkerOutputHasRangeOf()
+    {
+#if DEBUG
+        CompileOptions.DumpFlags = Diagnostics.DumpFlags.Rewrite | Diagnostics.DumpFlags.EGraphCost;
+#endif
         var a = new IR.Var("a", new IR.TensorType(DataTypes.Float32, new[] { 1, 3, 8, 8 }));
         var main = new IR.Function(new IR.Tuple(Relu(IR.F.Math.RangeOfMarker(a, new[] { -1.0f, 1.0f }))), new[] { a });
         var module = new IR.IRModule(main);
+        await TestAddMarkerPasses(module);
+        Assert.True(((IR.Function)module.Entry!).Body is IR.Tuple tuple && tuple.Fields[0] is IR.Marker);
+    }
+
+    [Fact]
+    public async Task TestAddMarkerOutputFalse()
+    {
+#if DEBUG
+        CompileOptions.DumpFlags = Diagnostics.DumpFlags.Rewrite | Diagnostics.DumpFlags.EGraphCost;
+#endif
+        var a = new IR.Var("a", new IR.TensorType(DataTypes.Float32, new[] { 1, 3, 8, 8 }));
+        var main = new IR.Function(new IR.Tuple(IR.F.Math.Unary(UnaryOp.LogicalNot, IR.F.Math.RangeOfMarker(a, new[] { -1.0f, 1.0f }))), new[] { a });
+        var module = new IR.IRModule(main);
+        await TestAddMarkerPasses(module);
+        Assert.True(((IR.Function)module.Entry!).Body is IR.Tuple tuple && tuple.Fields[0] is IR.Call);
+    }
+
+    private async Task TestAddMarkerPasses(IR.IRModule module)
+    {
         var passManager = CompileSession.CreatePassManager("manager");
         passManager.AddWithName<DataflowPass>("AddRangeOfMarker").Configure(p =>
         {
             p.Add<Transform.Rules.Neutral.AddRangeOfAndMarker>();
-            p.Add<Transform.Rules.Neutral.AddRangeOfAndMarkerOnFuncBody>();
         });
         await passManager.RunAsync(module);
-
-        Assert.True(((IR.Function)module.Entry!).Body is IR.Tuple tuple && tuple.Fields[0] is IR.Marker);
     }
 }

--- a/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
+++ b/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
@@ -102,3 +102,24 @@ public partial class AddRangeOfAndMarker : RewriteRule<Pattern>
         };
     }
 }
+
+/// <summary>
+/// add rangeofmarker on the function body.
+/// </summary>
+[RuleGenerator]
+public partial class AddRangeOfAndMarkerOnFunction : RewriteRule<Pattern>
+{
+    /// <inheritdoc/>
+    public override Pattern Pattern { get; } = IsFunction("func",
+      IsCallWildcard(
+          "call",
+          IsOp<Op>("op"),
+          IsWildcard("input")), IsVArgsRepeat("parameters", () => IsVar()));
+
+    private Expr? GetReplace(Call call, Op op, IReadOnlyList<Expr> callParams, Function func, IReadOnlyList<Expr> parameters)
+    {
+        var newCall = new Call(op, ImmutableArray.CreateRange(callParams));
+        var marker = IR.F.Math.RangeOfMarker(newCall, IR.F.Math.RangeOf(newCall));
+        return func with { Body = marker, Parameters = ImmutableArray.CreateRange(parameters.Select(e => (Var)e)) };
+    }
+}

--- a/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
+++ b/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
@@ -61,7 +61,8 @@ public partial class AddRangeOfAndMarker : RewriteRule<Pattern>
       IsCallWildcard(
           "call",
           IsOp<Op>("op"),
-          IsWildcard("input"));
+          IsWildcard("input")) with
+      { TypePattern = HasDataType(DataTypes.Float32) };
 
     /// <summary>
     /// check op.

--- a/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
+++ b/src/Nncase.Transform/Rules/Neutral/AddRangeOfAndMarker.cs
@@ -110,7 +110,8 @@ public partial class AddRangeOfAndMarker : RewriteRule<Pattern>
 public partial class AddRangeOfAndMarkerOnFunction : RewriteRule<Pattern>
 {
     /// <inheritdoc/>
-    public override Pattern Pattern { get; } = IsFunction("func",
+    public override Pattern Pattern { get; } = IsFunction(
+        "func",
       IsCallWildcard(
           "call",
           IsOp<Op>("op"),


### PR DESCRIPTION
1. fix function body no rangeof marker.
when the call inputs added the marker, the AddRangeOfMarker Rule can't match. So we can't add marker on the function body.
```il
  %337 = %336@(RangeOf = const(f32[2] : {-23.41534,19.147308})): // f32[1,7,7,2048]
  %338 = Relu(%337): // f32[1,7,7,2048] the relu inputs has marker.
  %339 = (%338): // (f32[1,7,7,2048])
```
