### PR TITLE
Only dump function which  mutated.

### DIFF
--- a/src/Nncase.Core/Transform/PassManager.cs
+++ b/src/Nncase.Core/Transform/PassManager.cs
@@ -184,17 +184,7 @@ internal sealed class PassManager : IPassManager
             var post = await pass.RunAsync(pre, context);
             if (!object.ReferenceEquals(pre, post))
             {
-                if (_dummper.IsEnabled(DumpFlags.PassIR))
-                {
-                    _dummper.DumpIR(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
-                }
-
                 module.Replace(i, post);
-
-                if (_dummper.IsEnabled(DumpFlags.PassIR))
-                {
-                    _dummper.DumpIR(post, string.Empty, $"{passIndex}_{pass.Name}/After");
-                }
             }
         }
 
@@ -212,17 +202,7 @@ internal sealed class PassManager : IPassManager
                 var post = await pass.RunAsync(pf, context);
                 if (!object.ReferenceEquals(pre, post))
                 {
-                    if (_dummper.IsEnabled(DumpFlags.PassIR))
-                    {
-                        _dummper.DumpIR(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
-                    }
-
                     module.Replace(i, post);
-
-                    if (_dummper.IsEnabled(DumpFlags.PassIR))
-                    {
-                        _dummper.DumpIR(post, string.Empty, $"{passIndex}_{pass.Name}/After");
-                    }
                 }
             }
         }

--- a/src/Nncase.Core/Transform/PassManager.cs
+++ b/src/Nncase.Core/Transform/PassManager.cs
@@ -186,14 +186,14 @@ internal sealed class PassManager : IPassManager
             {
                 if (_dummper.IsEnabled(DumpFlags.PassIR))
                 {
-                    _dummper.DumpModule(module, $"{passIndex}_{pass.Name}/Before");
+                    _dummper.DumpIR(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
                 }
 
                 module.Replace(i, post);
 
                 if (_dummper.IsEnabled(DumpFlags.PassIR))
                 {
-                    _dummper.DumpModule(module, $"{passIndex}_{pass.Name}/After");
+                    _dummper.DumpIR(post, string.Empty, $"{passIndex}_{pass.Name}/After");
                 }
             }
         }
@@ -214,14 +214,14 @@ internal sealed class PassManager : IPassManager
                 {
                     if (_dummper.IsEnabled(DumpFlags.PassIR))
                     {
-                        _dummper.DumpModule(module, $"{passIndex}_{pass.Name}/Before");
+                        _dummper.DumpIR(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
                     }
 
                     module.Replace(i, post);
 
                     if (_dummper.IsEnabled(DumpFlags.PassIR))
                     {
-                        _dummper.DumpModule(module, $"{passIndex}_{pass.Name}/After");
+                        _dummper.DumpIR(post, string.Empty, $"{passIndex}_{pass.Name}/After");
                     }
                 }
             }

--- a/src/Nncase.Core/Transform/PassManager.cs
+++ b/src/Nncase.Core/Transform/PassManager.cs
@@ -188,6 +188,11 @@ internal sealed class PassManager : IPassManager
             }
         }
 
+        if (_dummper.IsEnabled(DumpFlags.PassIR))
+        {
+            _dummper.DumpModule(module, $"{passIndex}_{pass.Name}");
+        }
+
         return module;
     }
 
@@ -205,6 +210,11 @@ internal sealed class PassManager : IPassManager
                     module.Replace(i, post);
                 }
             }
+        }
+
+        if (_dummper.IsEnabled(DumpFlags.PassIR))
+        {
+            _dummper.DumpModule(module, $"{passIndex}_{pass.Name}");
         }
 
         return module;

--- a/src/Nncase.Core/Transform/PrimFuncPass.cs
+++ b/src/Nncase.Core/Transform/PrimFuncPass.cs
@@ -109,10 +109,25 @@ public class PrimFuncPass : Pass<PrimFunction>, IMutatorsAddable
     }
 
     /// <inheritdoc/>
-    protected override Task OnPassStartAsync(PrimFunction input, RunPassContext context) => Task.CompletedTask;
+    protected override Task OnPassStartAsync(PrimFunction input, RunPassContext context)
+    {
+        if (DumpScope.Current.IsEnabled(DumpFlags.PassIR))
+        {
+            DumpScope.Current.DumpIR(input, "Start");
+        }
+        return Task.CompletedTask;
+    }
 
     /// <inheritdoc/>
-    protected override Task OnPassEndAsync(PrimFunction post, RunPassContext context) => Task.CompletedTask;
+    protected override Task OnPassEndAsync(PrimFunction post, RunPassContext context)
+    {
+        if (DumpScope.Current.IsEnabled(DumpFlags.PassIR))
+        {
+            DumpScope.Current.DumpIR(post, "End");
+        }
+
+        return Task.CompletedTask;
+    }
 
     private protected override string? GetDumpRelativePass(PrimFunction input) => input.Name;
 

--- a/src/Nncase.Core/Transform/PrimFuncPass.cs
+++ b/src/Nncase.Core/Transform/PrimFuncPass.cs
@@ -115,6 +115,7 @@ public class PrimFuncPass : Pass<PrimFunction>, IMutatorsAddable
         {
             DumpScope.Current.DumpIR(input, "Start");
         }
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
we don't need dump whole module in once rewrite.
```csharp
           if (!object.ReferenceEquals(pre, post))
            {
                if (_dummper.IsEnabled(DumpFlags.PassIR))
                {
                   // _dummper.DumpModule(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
                   _dummper.DumpIR(pre, string.Empty, $"{passIndex}_{pass.Name}/Before");
                }
            }
```