### PR TITLE
Fix EGraph Cost Accumulation

### DIFF
--- a/src/Nncase.Core/CompilerServices.cs
+++ b/src/Nncase.Core/CompilerServices.cs
@@ -70,7 +70,9 @@ public interface ICompilerServicesProvider
     /// <param name="expr">expression.</param>
     /// <param name="prefix">file prefix.</param>
     /// <param name="dumpDir">file dump ir.</param>
-    public void DumpCSharpIR(Expr expr, string prefix, string dumpDir);
+    /// <param name="randConst">false for save const into bin.</param>
+    public void DumpCSharpIR(Expr expr, string prefix, string dumpDir, bool randConst);
+
 
     /// <summary>
     /// print ir type.
@@ -421,8 +423,9 @@ public static class CompilerServices
     /// <param name="expr">expression.</param>
     /// <param name="prefix">file prefix.</param>
     /// <param name="dumpDir">file dump ir.</param>
-    public static void DumpCSharpIR(Expr expr, string prefix, string dumpDir) =>
-      Provider.DumpCSharpIR(expr, prefix, dumpDir);
+    /// <param name="randConst">randConst = false will save the const into bin.</param>
+    public static void DumpCSharpIR(Expr expr, string prefix, string dumpDir, bool randConst = true) =>
+      Provider.DumpCSharpIR(expr, prefix, dumpDir, randConst);
 
     public static string Print(IRType type) => Provider.Print(type);
 
@@ -530,8 +533,8 @@ internal class CompilerServicesProvider : ICompilerServicesProvider, ICompilerSe
     _irprinterProvider.DumpDotIR(expr, prefix, dumpPath, display_callable);
 
     /// <inheritdoc/>
-    public void DumpCSharpIR(Expr expr, string prefix, string dumpPath) =>
-    _irprinterProvider.DumpCSharpIR(expr, prefix, dumpPath);
+    public void DumpCSharpIR(Expr expr, string prefix, string dumpDir, bool randConst) =>
+    _irprinterProvider.DumpCSharpIR(expr, prefix, dumpDir, randConst);
 
     /// <inheritdoc/>
     public string Print(IRType type) => _irprinterProvider.Print(type);

--- a/src/Nncase.Core/CompilerServices.cs
+++ b/src/Nncase.Core/CompilerServices.cs
@@ -73,7 +73,6 @@ public interface ICompilerServicesProvider
     /// <param name="randConst">false for save const into bin.</param>
     public void DumpCSharpIR(Expr expr, string prefix, string dumpDir, bool randConst);
 
-
     /// <summary>
     /// print ir type.
     /// </summary>

--- a/src/Nncase.Core/IR/CSharpPrintVisitor.cs
+++ b/src/Nncase.Core/IR/CSharpPrintVisitor.cs
@@ -19,7 +19,6 @@ internal sealed class CSharpPrintVisitor : ExprFunctor<string, string>
     private readonly ScopeWriter _scope;
     private readonly Dictionary<Expr, string> _names = new Dictionary<Expr, string>(ReferenceEqualityComparer.Instance);
     private readonly BinaryWriter _constWriter;
-    private int _localId;
     private readonly bool _randConst;
     private int _localId;
 

--- a/src/Nncase.Core/IR/CSharpPrintVisitor.cs
+++ b/src/Nncase.Core/IR/CSharpPrintVisitor.cs
@@ -18,8 +18,8 @@ internal sealed class CSharpPrintVisitor : ExprFunctor<string, string>
 {
     private readonly ScopeWriter _scope;
     private readonly Dictionary<Expr, string> _names = new Dictionary<Expr, string>(ReferenceEqualityComparer.Instance);
-    private int _localId;
     private readonly BinaryWriter _constWriter;
+    private int _localId;
     private readonly bool _randConst;
 
     public CSharpPrintVisitor(TextWriter textWriter, BinaryWriter constWriter, int indent_level, bool randConst, bool withHeader = true)
@@ -46,6 +46,7 @@ internal sealed class CSharpPrintVisitor : ExprFunctor<string, string>
                     _scope.IndWriteLine("return Tensor.FromBytes<T>(__reader.ReadBytes(__size), __shape);");
                 }
             }
+
             _scope.IndWriteLine("}");
             if (_randConst)
             {

--- a/src/Nncase.Core/IR/CSharpPrintVisitor.cs
+++ b/src/Nncase.Core/IR/CSharpPrintVisitor.cs
@@ -21,6 +21,7 @@ internal sealed class CSharpPrintVisitor : ExprFunctor<string, string>
     private readonly BinaryWriter _constWriter;
     private int _localId;
     private readonly bool _randConst;
+    private int _localId;
 
     public CSharpPrintVisitor(TextWriter textWriter, BinaryWriter constWriter, int indent_level, bool randConst, bool withHeader = true)
     {

--- a/src/Nncase.Core/IR/IIRPrinterProvider.cs
+++ b/src/Nncase.Core/IR/IIRPrinterProvider.cs
@@ -70,7 +70,8 @@ public interface IIRPrinterProvider
     /// <param name="expr">expression.</param>
     /// <param name="prefix">file prefix.</param>
     /// <param name="dumpDir">file dump ir.</param>
-    public void DumpCSharpIR(Expr expr, string prefix, string dumpDir);
+    /// <param name="randConst">randConst = false will save the const into bin.</param>
+    public void DumpCSharpIR(Expr expr, string prefix, string dumpDir, bool randConst);
 
     /// <summary>
     /// print ir type.

--- a/src/Nncase.Core/TensorOfT.cs
+++ b/src/Nncase.Core/TensorOfT.cs
@@ -738,6 +738,7 @@ internal sealed class TensorOfT
         { typeof(float).TypeHandle, "f" },
         { typeof(double).TypeHandle, "d" },
         { typeof(long).TypeHandle, "L" },
-        { typeof(uint).TypeHandle, "UL" },
+        { typeof(uint).TypeHandle, "U" },
+        { typeof(ulong).TypeHandle, "UL" },
     };
 }

--- a/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
@@ -251,6 +251,7 @@ internal sealed class EGraphCostEvaluator
                 {
                     sequence.UnionWith(_eclassComputeSequence[child]);
                 }
+
                 _eclassComputeSequence[eclass] = sequence;
             }
         }
@@ -297,6 +298,7 @@ internal sealed class EGraphCostEvaluator
         {
             difference.UnionWith(item.Sequence);
         }
+
         difference.IntersectWith(costs.Select(c => c.Class));
         return difference.Aggregate(Cost.Zero, (acc, e) => acc + _eclassCosts[e]);
     }

--- a/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
@@ -307,6 +307,8 @@ internal sealed class EGraphCostEvaluator
 
     private sealed record AccumulateSequence
     {
+        public readonly HashSet<EClass> Accumulated;
+
         public EClass Current;
 
         public AccumulateSequence(EClass current)
@@ -314,8 +316,6 @@ internal sealed class EGraphCostEvaluator
             Current = current;
             Accumulated = new();
         }
-
-        public readonly HashSet<EClass> Accumulated;
     }
 
     private sealed record EClassCost(EClass Class, Cost Cost, AccumulateSequence Sequence)

--- a/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
+++ b/src/Nncase.EGraph/CostModel/EGraphCostEvaluator.cs
@@ -307,15 +307,15 @@ internal sealed class EGraphCostEvaluator
 
     private sealed record AccumulateSequence
     {
-        public readonly HashSet<EClass> Accumulated;
-
-        public EClass Current;
-
         public AccumulateSequence(EClass current)
         {
             Current = current;
             Accumulated = new();
         }
+
+        public HashSet<EClass> Accumulated { get; }
+
+        public EClass Current { get; set; }
     }
 
     private sealed record EClassCost(EClass Class, Cost Cost, AccumulateSequence Sequence)

--- a/src/Nncase.Evaluator/CostEvaluateVisitor.cs
+++ b/src/Nncase.Evaluator/CostEvaluateVisitor.cs
@@ -54,7 +54,7 @@ internal sealed class CostEvaluateVisitor : ExprVisitor<Cost?, IRType>
 
     public override Cost VisitLeaf(Marker expr)
     {
-        return Cost.Zero;
+        return ExpressionMemo[expr.Target] ?? Cost.Zero;
     }
 
     public override Cost? VisitLeaf(IR.Tuple expr)

--- a/src/Nncase.Evaluator/NN/Activations.cs
+++ b/src/Nncase.Evaluator/NN/Activations.cs
@@ -22,6 +22,8 @@ public partial class CeluEvaluator : IEvaluator<Celu>, ITypeInferencer<Celu>, IC
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -57,6 +59,8 @@ public partial class EluEvaluator : IEvaluator<Elu>, ITypeInferencer<Elu>, ICost
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -98,6 +102,8 @@ public class HardSwishEvaluator : IEvaluator<HardSwish>, ITypeInferencer<HardSwi
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -133,6 +139,8 @@ public class LeakyReluEvaluator : IEvaluator<LeakyRelu>, ITypeInferencer<LeakyRe
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -232,6 +240,8 @@ public class SeluEvaluator : IEvaluator<Selu>, ITypeInferencer<Selu>, ICostEvalu
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -302,6 +312,8 @@ public class HardSigmoidEvaluator : IEvaluator<HardSigmoid>, ITypeInferencer<Har
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 
@@ -338,6 +350,8 @@ public class PReluEvaluator : IEvaluator<PRelu>, ITypeInferencer<PRelu>, ICostEv
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(outputType),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType),
+            [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
         };
     }
 

--- a/src/Nncase.Evaluator/NN/Conv2D.cs
+++ b/src/Nncase.Evaluator/NN/Conv2D.cs
@@ -65,7 +65,7 @@ public class Conv2DEvaluator : IEvaluator<Conv2D>, ITypeInferencer<Conv2D>, ICos
 
         if (weightsShape.IsFixed)
         {
-            var macPerElement = ((2 * inputShape[1] * weightsShape[2] * weightsShape[3] - 1) * inputShape[2] * inputShape[3] * outputShape[1]).FixedValue;
+            var macPerElement = (((2 * inputShape[1] * weightsShape[2] * weightsShape[3]) - 1) * inputShape[2] * inputShape[3] * outputShape[1]).FixedValue;
             var puMac = 1;
             return new()
             {
@@ -74,6 +74,7 @@ public class Conv2DEvaluator : IEvaluator<Conv2D>, ITypeInferencer<Conv2D>, ICos
                 [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
             };
         }
+
         return null;
     }
 

--- a/src/Nncase.Evaluator/NN/Conv2D.cs
+++ b/src/Nncase.Evaluator/NN/Conv2D.cs
@@ -57,21 +57,23 @@ public class Conv2DEvaluator : IEvaluator<Conv2D>, ITypeInferencer<Conv2D>, ICos
     {
         var inputType = context.GetArgumentType<TensorType>(target, Conv2D.Input);
         var weightsType = context.GetArgumentType<TensorType>(target, Conv2D.Weights);
-        var biasType = context.GetArgumentType<TensorType>(target, Conv2D.Bias);
-        var weightsShape = context.GetArgumentType<TensorType>(target, Conv2D.Weights).Shape;
         var outputType = context.GetReturnType<TensorType>();
+
+        var weightsShape = weightsType.Shape;
+        var inputShape = inputType.Shape;
+        var outputShape = outputType.Shape;
 
         if (weightsShape.IsFixed)
         {
-            var macPerElement = weightsShape[1] * weightsShape[2] * weightsShape[3];
+            var macPerElement = ((2 * inputShape[1] * weightsShape[2] * weightsShape[3] - 1) * inputShape[2] * inputShape[3] * outputShape[1]).FixedValue;
+            var puMac = 1;
             return new()
             {
-                [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType) + CostUtility.GetMemoryAccess(weightsType) + CostUtility.GetMemoryAccess(biasType),
+                [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType) + CostUtility.GetMemoryAccess(weightsType),
+                [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, macPerElement / puMac),
                 [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
-                [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, macPerElement.FixedValue * 2),
             };
         }
-
         return null;
     }
 

--- a/src/Nncase.Evaluator/TypeInference.cs
+++ b/src/Nncase.Evaluator/TypeInference.cs
@@ -190,6 +190,11 @@ public static class TypeInference
                 return new InvalidType($"The Input Channel / Groups Error ({input.Shape[1].FixedValue}/{groups_v})");
             }
 
+            if ((input.Shape[1] / groups_v) != weights.Shape[1])
+            {
+                return new InvalidType($"The input channel {input.Shape[1]} / {groups_v} != {weights.Shape[1]}");
+            }
+
             outShape[2] = GetWindowedOutputSize(
                 input.Shape[2].FixedValue + ts_padding[0, 0] + ts_padding[0, 1],
                 weights.Shape[2].FixedValue,

--- a/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
+++ b/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
@@ -17,8 +17,8 @@ public sealed class TestVisitor : ExprVisitor<bool, IRType>
     /// <summary>
     /// check Contains expr with type.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
+    /// <typeparam name="T">the expr type.</typeparam>
+    /// <returns>wether contains.</returns>
     public bool Contains<T>()
       where T : Expr
     {
@@ -28,8 +28,8 @@ public sealed class TestVisitor : ExprVisitor<bool, IRType>
     /// <summary>
     /// count call op numbers.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
+    /// <typeparam name="T">op type.</typeparam>
+    /// <returns>counts.</returns>
     public int CountCallOp<T>()
       where T : Op
     {

--- a/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
+++ b/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Canaan Inc. All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Nncase.IR;
+
+namespace Nncase.Tests;
+
+/// <summary>
+/// the visitor for test
+/// </summary>
+public sealed class TestVisitor : ExprVisitor<bool, IRType>
+{
+    /// <inheritdoc/>
+    public override bool DefaultVisitLeaf(Expr expr) => true;
+
+    /// <summary>
+    /// check Contains expr with type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public bool Contains<T>()
+      where T : Expr
+    {
+        return ExpressionMemo.Keys.OfType<T>().Any();
+    }
+
+    /// <summary>
+    /// count call op numbers.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public int CountCallOp<T>()
+      where T : Op
+    {
+        return ExpressionMemo.Keys.OfType<Call>().Where(call => call is { Target: T }).Count();
+    }
+}

--- a/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
+++ b/src/Nncase.Tests.TestFixture/TransformBase/TestVisitor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Canaan Inc. All rights reserved.
+﻿// Copyright (c) Canaan Inc. All rights reserved.
 // Licensed under the Apache license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
@@ -7,7 +7,7 @@ using Nncase.IR;
 namespace Nncase.Tests;
 
 /// <summary>
-/// the visitor for test
+/// the visitor for test.
 /// </summary>
 public sealed class TestVisitor : ExprVisitor<bool, IRType>
 {

--- a/src/Nncase.Tests/Core/UnitTestTypeInfer.cs
+++ b/src/Nncase.Tests/Core/UnitTestTypeInfer.cs
@@ -238,6 +238,16 @@ public class UnitTestTypeInfer : UnitTypeInferBase
     }
 
     [Fact]
+    public void TestConv2DInvalidWeights()
+    {
+        var v30 = new Var("serving_default_input_1:0", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+        var v30_1 = new Marker("RangeOf", Testing.Rand<float>(256, 64, 1, 1), new float[] { -0.3903954f, 0.46443018f }); // f32[256,64,1,1]
+        var v30_2 = new Call(new IR.NN.Conv2D(PadMode.Constant), new Expr[] { v30, v30_1, Testing.Rand<float>(256), new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { -float.PositiveInfinity, float.PositiveInfinity } }); // f32[1,256,56,56]
+        CompilerServices.InferenceType(v30_2);
+        Assert.IsType<InvalidType>(v30_2.CheckedType);
+    }
+
+    [Fact]
     public void TestConcat()
     {
         var v1 = Var(new[] { 1, 3, 16 });

--- a/src/Nncase.Tests/CostModel/UnitTestEGraphCostModel.cs
+++ b/src/Nncase.Tests/CostModel/UnitTestEGraphCostModel.cs
@@ -62,24 +62,6 @@ public sealed class UnitTestEGraphCostModel
         Assert.Equal(binrayOpCost! + binaryRhsCost!, rootCost);
     }
 
-    internal sealed class EvaluatorContext : Evaluator.ICostEvaluateContext
-    {
-        private readonly Call _currentCall;
-
-        public EvaluatorContext(Call call)
-        {
-            _currentCall = call;
-        }
-
-        public T GetArgumentType<T>(Op op, ParameterInfo parameter)
-            where T : IRType
-            => (T)_currentCall[parameter].CheckedType!;
-
-        public T GetReturnType<T>()
-            where T : IRType
-            => (T)_currentCall.CheckedType!;
-    }
-
     /// <summary>
     /// root = concat(tuple(a,a,b),1)
     /// root cost = concat op cost + a cost + b cost.
@@ -145,5 +127,23 @@ public sealed class UnitTestEGraphCostModel
         visitor.Visit(post);
 
         Assert.Equal(2, visitor.CountCallOp<Conv2D>());
+    }
+
+    internal sealed class EvaluatorContext : Evaluator.ICostEvaluateContext
+    {
+        private readonly Call _currentCall;
+
+        public EvaluatorContext(Call call)
+        {
+            _currentCall = call;
+        }
+
+        public T GetArgumentType<T>(Op op, ParameterInfo parameter)
+            where T : IRType
+            => (T)_currentCall[parameter].CheckedType!;
+
+        public T GetReturnType<T>()
+            where T : IRType
+            => (T)_currentCall.CheckedType!;
     }
 }

--- a/src/Nncase.Tests/CostModel/UnitTestEGraphCostModel.cs
+++ b/src/Nncase.Tests/CostModel/UnitTestEGraphCostModel.cs
@@ -1,2 +1,142 @@
 ﻿// Copyright (c) Canaan Inc. All rights reserved.
 // Licensed under the Apache license. See LICENSE file in the project root for full license information.
+
+using System;
+using Nncase;
+using Nncase.CostModel;
+using Nncase.IR;
+using Nncase.IR.Math;
+using Nncase.IR.NN;
+using Nncase.Tests.TestFixture;
+using Nncase.Transform;
+using Xunit;
+
+namespace Nncase.Tests.CostModelTest;
+
+/// <summary>
+/// test egraph costs
+/// </summary>
+public sealed class UnitTestEGraphCostModel
+{
+
+    internal sealed class EvaluatorContext : Evaluator.ICostEvaluateContext
+    {
+        private readonly Call CurrentCall;
+        public EvaluatorContext(Call call)
+        {
+            CurrentCall = call;
+        }
+        public T GetArgumentType<T>(Op op, ParameterInfo parameter) where T : IRType => (T)CurrentCall[parameter].CheckedType!;
+        public T GetReturnType<T>() where T : IRType => (T)CurrentCall.CheckedType!;
+    }
+
+    /// <summary>
+    /// root = x + conv2d(x) 
+    /// root cost = conv2d(x) cost + binary cost
+    /// </summary>
+    [Fact]
+    public void TestBinaryShortCutCost()
+    {
+        Tensor GetD<T>(System.IO.BinaryReader __reader, long __start, int __size, params int[] __shape)
+        where T : unmanaged, IEquatable<T>
+        {
+            // __reader.BaseStream.Seek(__start, System.IO.SeekOrigin.Begin);
+            var bytes = new byte[__size];
+            Testing.RandGenerator.NextBytes(bytes);
+            return Tensor.FromBytes<T>(bytes, __shape);
+        }
+        using var vD = new System.IO.BinaryReader(new System.IO.MemoryStream());
+        Function v0; // (f32[1,224,224,3]) -> (f32[1,7,7,2048])
+        var v30 = new Var("serving_default_input_1:0", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+        var v30_1 = new Marker("RangeOf", GetD<float>(vD, 269312, 65536, 256, 256, 1, 1), new float[] { -0.3903954f, 0.46443018f }); // f32[256,64,1,1]
+        var v30_2 = new Call(new Conv2D(PadMode.Constant), new Expr[] { v30, v30_1, GetD<float>(vD, 334848, 1024, 256), new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { -float.PositiveInfinity, float.PositiveInfinity } }); // f32[1,256,56,56]
+        var v30_3 = new Marker("RangeOf", v30_2, new float[] { -11.444157f, 10.850164f }); // f32[1,256,56,56]
+        var v31 = new Marker("RangeOf", v30_3, new float[] { -35.968758f, 32.784153f }); // f32[1,256,56,56]
+        var v46 = new Marker("RangeOf", GetD<float>(vD, 551424, 65536, 256, 256, 1, 1), new float[] { -0.4176304f, 0.74278486f }); // f32[256,64,1,1]
+        var v47 = new Call(new Conv2D(PadMode.Constant), new Expr[] { v31, v46, GetD<float>(vD, 616960, 1024, 256), new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { -float.PositiveInfinity, float.PositiveInfinity } }); // f32[1,256,56,56]
+        var v48 = new Marker("RangeOf", v47, new float[] { -8.493573f, 14.834768f }); // f32[1,256,56,56]
+        var v49 = new Call(new Binary(BinaryOp.Add), new Expr[] { v31, v48 }); // f32[1,256,56,56]
+        var v50 = new Marker("RangeOf", v49, new float[] { -35.823486f, 31.693804f }); // f32[1,256,56,56]
+        v0 = new Function("main", v50, new Var[] { v30 });
+        var binaryCost = CompilerServices.EvaluateCost(v49);
+        var binaryLhsCost = CompilerServices.EvaluateCost(v31);
+        var binaryRhsCost = CompilerServices.EvaluateCost(v48);
+
+        var eGraph = new EGraph();
+        var lhsClass = eGraph.Add(v31);
+        var rhsClass = eGraph.Add(v48);
+        var root = eGraph.Add(v50);
+
+        var costModel = new EGraphCostEvaluator(root, null).Evaluate();
+        var rootCost = costModel[root.Nodes[0]];
+        var binrayOpCost = CompilerServices.EvaluateOpCost((Op)v49.Target, new EvaluatorContext(v49));
+        Assert.Equal(binrayOpCost! + binaryRhsCost!, rootCost);
+    }
+
+    /// <summary>
+    /// root = concat(tuple(a,a,b),1)
+    /// root cost = concat op cost + a cost + b cost
+    /// </summary>
+    [Fact]
+    public void TestTupleCost()
+    {
+        var v1 = new Var("serving_default_input_1:0", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+        var a = v1 + Testing.Rand<float>(1, 256, 1, 1);
+        var b = v1 * Testing.Rand<float>(1, 256, 56, 56);
+        var tuple = new IR.Tuple(a, a, b);
+        var root = IR.F.Tensors.Concat(tuple, 1);
+        root.InferenceType();
+        var aCost = CompilerServices.EvaluateCost(a); // 2512,1476,369
+        var bCost = CompilerServices.EvaluateCost(b); // 2952,1476,738
+        var concatOpCost = CompilerServices.EvaluateOpCost((Op)root.Target, new EvaluatorContext(root)); // 
+
+        var eGraph = new EGraph();
+        var aClass = eGraph.Add(a);
+        var bClass = eGraph.Add(b);
+        var rootEclass = eGraph.Add(root);
+
+        var costModel = new EGraphCostEvaluator(rootEclass, null).Evaluate();
+        var rootCost = costModel[rootEclass.Nodes[0]];
+        Assert.Equal(aCost! + bCost! + concatOpCost!, rootCost);
+    }
+
+    /// <summary>
+    ///    input
+    ///      |
+    ///   conv2d
+    ///   /    \
+    ///   |   relu     =>  can't duplicate conv2d
+    ///   |     |
+    ///   |   conv2d
+    ///    \  /
+    ///    add 
+    /// </summary>
+    [Fact]
+    public void TestDuplicteConv2D()
+    {
+        var input = new Var("serving_default_input_1:0", new TensorType(DataTypes.Float32, new[] { 1, 256, 56, 56 }));
+
+        var v0W = Testing.Rand<float>(64, 256, 1, 1);
+        var v0B = Testing.Rand<float>(64);
+        var v0 = new Call(new Conv2D(PadMode.Constant), new Expr[] { input, v0W, v0B, new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { -float.PositiveInfinity, float.PositiveInfinity } }); // f32[1,64,56,56]
+        var v1 = IR.F.NN.Relu6(v0);
+        var v2 = new Call(new Conv2D(PadMode.Constant), new Expr[] { v1, Testing.Rand<float>(64, 64, 1, 1), Testing.Rand<float>(64), new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { -float.PositiveInfinity, float.PositiveInfinity } }); // f32[1,256,56,56]
+        var v3 = v0 + v2;
+        var v1Fused = new Call(new Conv2D(PadMode.Constant), new Expr[] { input, v0W, v0B, new int[] { 1, 1 }, new int[,] { { 0, 0 }, { 0, 0 } }, new int[] { 1, 1 }, 1, new float[] { 0, 6 } });
+        CompilerServices.InferenceType(v1Fused);
+        CompilerServices.InferenceType(v3);
+
+        var eGraph = new EGraph();
+        var v1Class = eGraph.Add(v1);
+        var v1FuseClass = eGraph.Add(v1Fused);
+        var root = eGraph.Add(v3);
+        eGraph.Union(v1Class, v1FuseClass);
+
+        var post = eGraph.Extract(root, null);
+
+        var visitor = new TestVisitor();
+        visitor.Visit(post);
+
+        Assert.Equal(2, visitor.CountCallOp<Conv2D>());
+    }
+}

--- a/src/Nncase.Tests/Diagnostics/UnitTestDumpper.cs
+++ b/src/Nncase.Tests/Diagnostics/UnitTestDumpper.cs
@@ -192,7 +192,8 @@ public sealed class UnitTestDumpper : TestClassBase
         var x = IR.F.Math.Quantize(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 2, 2, 2 }), Tensor.From<QuantParam>(new QuantParam[] { new(1, 2.0f), new(2, 3.0f) }, new[] { 2 }), DataTypes.UInt8);
         var y = new Var("y", new TensorType(DataTypes.UInt8, new int[] { 1, 2, 2, 2 }));
         var z = IR.F.Random.Normal(DataTypes.UInt8, 0, 1, 0, new[] { 1, 2, 2, 2 });
-        var main = new Function("main", IR.F.Tensors.Concat(new IR.Tuple(new Expr[] { x, y, z }), 1), new[] { y });
+        var m = IR.F.Random.Normal(DataTypes.UInt8, 0, 1, 0, new[] { 1, 20, 2, 2 });
+        var main = new Function("main", IR.F.Tensors.Concat(new IR.Tuple(new Expr[] { x, y, z, m }), 1), new[] { y });
         CompilerServices.DumpCSharpIR(main, string.Empty, Dumpper.Directory);
     }
 
@@ -206,9 +207,11 @@ public sealed class UnitTestDumpper : TestClassBase
         var n = IR.F.Math.RangeOfMarker(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 2, 2, 2 }), new long[] { 1L, 2L });
         var k = IR.F.Math.RangeOfMarker(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 2, 2, 2 }), new uint[] { 1u, 2u });
         var j = IR.F.Math.RangeOfMarker(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 2, 2, 2 }), new ulong[] { 1UL, 2UL });
-        var fusion = new Fusion("fusion", "stackvm", new IR.Tuple(new Expr[] { x, y, z, m, n, k, j }), Array.Empty<Var>());
+        var xx = IR.F.Math.RangeOfMarker(IR.F.Random.Normal(DataTypes.Float32, 0, 1, 0, new[] { 1, 8, 2, 2 }), new ulong[] { 1UL, 2UL });
+        var xy = IR.F.Math.RangeOfMarker(IR.F.Tensors.Cast(IR.F.Random.Normal(DataTypes.BFloat16, 0, 1, 0, new[] { 1, 9, 2, 2 }), DataTypes.Float32), new ulong[] { 1UL, 2UL });
+        var fusion = new Fusion("fusion", "stackvm", new IR.Tuple(new Expr[] { x, y, z, m, n, k, j, xx, xy }), Array.Empty<Var>());
         var main = new Function("main", IR.F.Tensors.Concat(new Call(fusion, Array.Empty<Expr>()), 1), Array.Empty<Var>());
-        CompilerServices.DumpCSharpIR(main, string.Empty, Dumpper.Directory);
+        CompilerServices.DumpCSharpIR(main, string.Empty, Dumpper.Directory, false);
     }
 
     private async Task<Expr> RunShapeInferPass(string name, Expr expr, params Var[] parameters)


### PR DESCRIPTION
1. the old egraph extract using `costs.sum()` for accumulate costs, when the children nodes in same compute sequence, it will accumulate more costs.
eg. `x + conv(x)`, the `root cost = add op cost + conv(x) cost + x cost`. 
now add the compute sequence hashset, `x + conv(x) cost = add op cost + conv(x) cost`.
2. add `CSharpIRDump` randConst mode. when randConst == false, will write const into bin file.