### PR TITLE
speed up unroll evaluate

### DIFF
--- a/src/Native/src/kernels/stackvm/reference/activation.cpp
+++ b/src/Native/src/kernels/stackvm/reference/activation.cpp
@@ -21,6 +21,7 @@
 #include <nncase/runtime/host_buffer.h>
 #include <nncase/runtime/runtime_op_utility.h>
 #include <nncase/runtime/util.h>
+#include <math.h>
 
 using namespace nncase;
 using namespace nncase::runtime;
@@ -35,7 +36,7 @@ FLOAT_UNARY_TEMPLATE(sigmoid, 1 / (1 + exp(-x)))
 FLOAT_UNARY_TEMPLATE(hard_swish,
                      x *std::max(0.f, std::min((float)1.f,
                                                (float)(1.f / 6 * x + 0.5))))
-FLOAT_UNARY_TEMPLATE(erf, std::erf(x))
+FLOAT_UNARY_TEMPLATE(erf, erff(x)) // for k510 toolchain
 FLOAT_UNARY_WITH_MUL_TEMPLATE(elu, alpha, x < 0 ? alpha * (exp(x) - 1) : x)
 // FLOAT_UNARY_WITH_MUL_TEMPLATE(prelu, slope, x < 0 ? slope * x : x)
 FLOAT_UNARY_WITH_MUL_TEMPLATE(

--- a/src/Native/src/kernels/stackvm/reference/activation.cpp
+++ b/src/Native/src/kernels/stackvm/reference/activation.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "kernel_template.h"
+#include <math.h>
 #include <nncase/kernels/apply.h>
 #include <nncase/kernels/kernel_utils.h>
 #include <nncase/kernels/stackvm/tensor_ops.h>
@@ -21,7 +22,6 @@
 #include <nncase/runtime/host_buffer.h>
 #include <nncase/runtime/runtime_op_utility.h>
 #include <nncase/runtime/util.h>
-#include <math.h>
 
 using namespace nncase;
 using namespace nncase::runtime;

--- a/src/Nncase.Core/Transform/Mutators/UnRollLoopSequential.cs
+++ b/src/Nncase.Core/Transform/Mutators/UnRollLoopSequential.cs
@@ -181,10 +181,13 @@ public sealed class UnRollLoopSequential : ExprMutator
         public override Expr MutateLeaf(Call expr)
         {
             if (expr.Target is Op op && op.GetType().Namespace is string @namespace
-              && (@namespace.StartsWith("Nncase.IR.Math") || @namespace.StartsWith("Nncase.IR.Tensors"))
-              && expr.Parameters.Select(Visit).All(e => e is Const))
+              && (@namespace.StartsWith("Nncase.IR.Math") || @namespace.StartsWith("Nncase.IR.Tensors")))
             {
-                return StructEqualFolding(Const.FromValue(CompilerServices.Evaluate(expr, _cmap, _evaluator_cache)));
+                var newParameters = ImmutableArray.CreateRange(expr.Parameters.Select(Visit));
+                if (newParameters.All(e => e is Const))
+                {
+                    return StructEqualFolding(Const.FromValue(CompilerServices.Evaluate(expr with { Parameters = newParameters }, _cmap, _evaluator_cache)));
+                }
             }
 
             if (expr.Target is Function fn)


### PR DESCRIPTION
1. use cached const parameters to speed up the next evaluation
2. add egraph CSE test case