### PR TITLE
Fix EGraph Cost accumulate bug

### DIFF
--- a/src/Nncase.Core/CostModel/Cost.cs
+++ b/src/Nncase.Core/CostModel/Cost.cs
@@ -213,7 +213,7 @@ public static class CostUtility
         };
     }
 
-    public static UInt128 GetCPUCycles(IRType type, uint cyclesPerElement = 1)
+    public static UInt128 GetCPUCycles(IRType type, double cyclesPerElement = 1)
     {
         return type switch
         {

--- a/src/Nncase.Core/CostModel/Cost.cs
+++ b/src/Nncase.Core/CostModel/Cost.cs
@@ -192,7 +192,7 @@ public static class CostUtility
     {
         return type switch
         {
-            TensorType t => (UInt128)(t.Shape.Sum(x => x.IsFixed ? x.FixedValue : 1) * t.DType.SizeInBytes),
+            TensorType t => (UInt128)(t.Shape.Aggregate(1D, (acc, x) => acc * (x.IsFixed ? x.FixedValue : 1)) * t.DType.SizeInBytes),
             TupleType t => t.Fields.Sum(GetMemoryAccess),
             _ => 0,
         };
@@ -207,7 +207,7 @@ public static class CostUtility
     {
         return type switch
         {
-            TensorType t => (UInt128)Math.Ceiling((float)t.Shape.Sum(x => x.IsFixed ? x.FixedValue : 1) * t.DType.SizeInBytes * bits / 8),
+            TensorType t => (UInt128)Math.Ceiling((float)t.Shape.Aggregate(1D, (acc, x) => acc * (x.IsFixed ? x.FixedValue : 1)) * t.DType.SizeInBytes * bits / 8),
             TupleType t => t.Fields.Sum(x => GetFakeMemoryAccess(x, bits)),
             _ => 0,
         };
@@ -217,7 +217,7 @@ public static class CostUtility
     {
         return type switch
         {
-            TensorType t => (UInt128)(t.Shape.Sum(x => x.IsFixed ? x.FixedValue : 1) * cyclesPerElement),
+            TensorType t => (UInt128)(t.Shape.Aggregate(1D, (acc, x) => acc * (x.IsFixed ? x.FixedValue : 1)) * cyclesPerElement),
             TupleType t => t.Fields.Sum(GetMemoryAccess),
             _ => 0,
         };

--- a/src/Nncase.Core/LinqExtensions.cs
+++ b/src/Nncase.Core/LinqExtensions.cs
@@ -43,4 +43,26 @@ public static class LinqExtensions
 
         return items;
     }
+
+    public static UInt128 Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, UInt128> selector)
+    {
+        UInt128 acc = 0;
+        foreach (var item in source)
+        {
+            acc += selector(item);
+        }
+
+        return acc;
+    }
+
+    public static UInt128 Sum(this IEnumerable<UInt128> source)
+    {
+        UInt128 acc = 0;
+        foreach (var item in source)
+        {
+            acc += item;
+        }
+
+        return acc;
+    }
 }

--- a/src/Nncase.Evaluator/Math/MatMul.cs
+++ b/src/Nncase.Evaluator/Math/MatMul.cs
@@ -43,7 +43,7 @@ public class MatMulEvaluator : IEvaluator<MatMul>, ITypeInferencer<MatMul>, ICos
             Console.WriteLine("unrank");
         }
 
-        var macPerElement = lhs.Shape[^1].IsFixed ? lhs.Shape[^1].FixedValue : 1;
+        uint macPerElement = lhs.Shape[^1].IsFixed ? (uint)lhs.Shape[^1].FixedValue : 1U;
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(lhs) + CostUtility.GetMemoryAccess(rhs),

--- a/src/Nncase.Evaluator/Math/Quantize.cs
+++ b/src/Nncase.Evaluator/Math/Quantize.cs
@@ -46,8 +46,8 @@ public class QuantizeEvaluator : IEvaluator<Quantize>, ITypeInferencer<Quantize>
         var quant_param = context.GetArgumentType<TensorType>(target, Quantize.QuantParam);
         var output = context.GetReturnType<TensorType>();
 
-        var macPerElement = 1;
-        var macParallel = 1;
+        uint macPerElement = 1;
+        uint macParallel = 1;
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(input) +

--- a/src/Nncase.Evaluator/Math/Reduce.cs
+++ b/src/Nncase.Evaluator/Math/Reduce.cs
@@ -80,9 +80,9 @@ public class ReduceEvaluator : IEvaluator<Reduce>, ITypeInferencer<Reduce>, ICos
     {
         var input = context.GetArgumentType<TensorType>(target, Reduce.Input);
         var ret = context.GetReturnType<TensorType>();
-        var input_elem = input.Shape.Aggregate(1, (acc, d) => acc * (d.IsFixed ? d.FixedValue : 1));
-        var ret_elem = ret.Shape.Aggregate(1, (acc, d) => acc * (d.IsFixed ? d.FixedValue : 1));
-        var macPerElement = input_elem / ret_elem;
+        uint input_elem = input.Shape.Aggregate(1U, (acc, d) => acc * (d.IsFixed ? (uint)d.FixedValue : 1U));
+        uint ret_elem = ret.Shape.Aggregate(1U, (acc, d) => acc * (d.IsFixed ? (uint)d.FixedValue : 1U));
+        uint macPerElement = input_elem / ret_elem;
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(input),

--- a/src/Nncase.Evaluator/Math/ReduceArg.cs
+++ b/src/Nncase.Evaluator/Math/ReduceArg.cs
@@ -48,9 +48,9 @@ public class ReduceArgEvaluator : IEvaluator<ReduceArg>, ITypeInferencer<ReduceA
     {
         var input = context.GetArgumentType<TensorType>(target, ReduceArg.Input);
         var ret = context.GetReturnType<TensorType>();
-        var input_elem = input.Shape.Aggregate(1, (acc, d) => acc * (d.IsFixed ? d.FixedValue : 1));
-        var ret_elem = ret.Shape.Aggregate(1, (acc, d) => acc * (d.IsFixed ? d.FixedValue : 1));
-        var macPerElement = input_elem / ret_elem;
+        uint input_elem = input.Shape.Aggregate(1U, (acc, d) => acc * (d.IsFixed ? (uint)d.FixedValue : 1U));
+        uint ret_elem = ret.Shape.Aggregate(1U, (acc, d) => acc * (d.IsFixed ? (uint)d.FixedValue : 1U));
+        uint macPerElement = input_elem / ret_elem;
         return new() { [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(input), [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(ret), [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(ret, macPerElement), };
     }
 

--- a/src/Nncase.Evaluator/NN/Activations.cs
+++ b/src/Nncase.Evaluator/NN/Activations.cs
@@ -274,7 +274,7 @@ public class SigmoidEvaluator : IEvaluator<Sigmoid>, ITypeInferencer<Sigmoid>, I
     public Cost Visit(ICostEvaluateContext context, Sigmoid target)
     {
         var ret = context.GetReturnType<TensorType>();
-        var macPerElement = 3;
+        uint macPerElement = 3;
         return CostUtility.GetActivationCost(ret, macPerElement);
     }
 

--- a/src/Nncase.Evaluator/NN/Conv2D.cs
+++ b/src/Nncase.Evaluator/NN/Conv2D.cs
@@ -66,7 +66,7 @@ public class Conv2DEvaluator : IEvaluator<Conv2D>, ITypeInferencer<Conv2D>, ICos
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType) + CostUtility.GetMemoryAccess(weightsType) + CostUtility.GetMemoryAccess(biasType),
             [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType),
-            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, macPerElement.FixedValue),
+            [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, (uint)macPerElement.FixedValue),
         };
     }
 

--- a/src/Nncase.Evaluator/NN/Conv2DTranspose.cs
+++ b/src/Nncase.Evaluator/NN/Conv2DTranspose.cs
@@ -71,6 +71,6 @@ public class Conv2DTransposeEvaluator : IEvaluator<Conv2DTranspose>, ITypeInfere
         var outputType = context.GetReturnType<TensorType>();
 
         var macPerElement = weightsShape[1] * weightsShape[2] * weightsShape[3];
-        return new() { [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType) + CostUtility.GetMemoryAccess(weightsType) + CostUtility.GetMemoryAccess(biasType), [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType), [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, macPerElement.FixedValue * 2), };
+        return new() { [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType) + CostUtility.GetMemoryAccess(weightsType) + CostUtility.GetMemoryAccess(biasType), [CostFactorNames.MemoryStore] = CostUtility.GetMemoryAccess(outputType), [CostFactorNames.CPUCycles] = CostUtility.GetCPUCycles(outputType, (uint)macPerElement.FixedValue * 2), };
     }
 }

--- a/src/Nncase.Evaluator/NN/Hardmax.cs
+++ b/src/Nncase.Evaluator/NN/Hardmax.cs
@@ -36,7 +36,7 @@ public class HardmaxEvaluator : IEvaluator<Hardmax>, ITypeInferencer<Hardmax>, I
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType),
-            [CostFactorNames.MemoryStore] = (double)inputType.Shape.Rank,
+            [CostFactorNames.MemoryStore] = (UInt128)inputType.Shape.Rank,
         };
     }
 

--- a/src/Nncase.Evaluator/NN/ReduceWindow2D.cs
+++ b/src/Nncase.Evaluator/NN/ReduceWindow2D.cs
@@ -79,7 +79,7 @@ public class ReduceWindow2DEvaluator : IEvaluator<ReduceWindow2D>, ITypeInferenc
         var inputType = context.GetArgumentType<TensorType>(target, ReduceWindow2D.Input);
         var outputType = context.GetReturnType<TensorType>();
 
-        var macPerElement = 1;
+        uint macPerElement = 1;
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(inputType),

--- a/src/Nncase.Evaluator/NN/Softmax.cs
+++ b/src/Nncase.Evaluator/NN/Softmax.cs
@@ -32,7 +32,7 @@ public class LogSoftmaxEvaluator : IEvaluator<LogSoftmax>, ITypeInferencer<LogSo
     public Cost Visit(ICostEvaluateContext context, LogSoftmax target)
     {
         var ret = context.GetReturnType<TensorType>();
-        var macPerElement = 4;
+        uint macPerElement = 4;
         return new()
         {
             [CostFactorNames.MemoryLoad] = CostUtility.GetMemoryAccess(ret),

--- a/src/Nncase.Evaluator/RNN/LSTM.cs
+++ b/src/Nncase.Evaluator/RNN/LSTM.cs
@@ -67,7 +67,7 @@ public class LSTMEvaluator : IEvaluator<LSTM>, ITypeInferencer<LSTM>, ICostEvalu
             [CostFactorNames.MemoryStore] = returnType.Select(t => t switch
             {
                 TensorType tensorType => CostUtility.GetMemoryAccess(tensorType),
-                _ => 1,
+                _ => UInt128.One,
             }).Sum(),
         };
     }

--- a/src/Nncase.Tests/Core/UnitTestCost.cs
+++ b/src/Nncase.Tests/Core/UnitTestCost.cs
@@ -16,61 +16,61 @@ public sealed class UnitTestCost
     [Fact]
     public void TestGetCPUCyclesOfUnary()
     {
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Abs));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Acos));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Acosh));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Asin));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Asinh));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Ceil));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Cos));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Cosh));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Exp));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Floor));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Log));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Neg));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Round));
-        Assert.Equal(4, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Rsqrt));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sin));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sinh));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sign));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sqrt));
-        Assert.Equal(2, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Square));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Tanh));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.BitwiseNot));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.LogicalNot));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Abs));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Acos));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Acosh));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Asin));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Asinh));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Ceil));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Cos));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Cosh));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Exp));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Floor));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Log));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Neg));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Round));
+        Assert.Equal((UInt128)4, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Rsqrt));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sin));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sinh));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sign));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Sqrt));
+        Assert.Equal((UInt128)2, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Square));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfUnary(UnaryOp.Tanh));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.BitwiseNot));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfUnary(UnaryOp.LogicalNot));
     }
 
     [Fact]
     public void TestGetCPUCyclesOfBinary()
     {
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Add));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Sub));
-        Assert.Equal(2, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Mul));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Div));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Mod));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Min));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Max));
-        Assert.Equal(8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Pow));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseAnd));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseOr));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseXor));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalAnd));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalOr));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalXor));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LeftShift));
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.RightShift));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Add));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Sub));
+        Assert.Equal((UInt128)2, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Mul));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Div));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Mod));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Min));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Max));
+        Assert.Equal((UInt128)8, CostUtility.GetCPUCyclesOfBinary(BinaryOp.Pow));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseAnd));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseOr));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.BitwiseXor));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalAnd));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalOr));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LogicalXor));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.LeftShift));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfBinary(BinaryOp.RightShift));
     }
 
     [Fact]
     public void TestGetCPUCyclesOfMax()
     {
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfMax());
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfMax());
     }
 
     [Fact]
     public void TestGetCPUCyclesOfCompare()
     {
-        Assert.Equal(1, CostUtility.GetCPUCyclesOfCompare());
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCyclesOfCompare());
     }
 
     [Fact]
@@ -98,20 +98,39 @@ public sealed class UnitTestCost
     [Fact]
     public void TestGetCPUCycles()
     {
-        Assert.Equal(0, CostUtility.GetCPUCycles(DataTypes.Int32));
-        Assert.Equal(0, CostUtility.GetCPUCycles(new TupleType(new List<IRType>())));
+        Assert.Equal((UInt128)0, CostUtility.GetCPUCycles(DataTypes.Int32));
+        Assert.Equal((UInt128)0, CostUtility.GetCPUCycles(new TupleType(new List<IRType>())));
     }
 
     [Fact]
     public void TestGetFakeMemoryAccess()
     {
-        Assert.Equal(0, CostUtility.GetFakeMemoryAccess(DataTypes.Float32, 0));
-        Assert.Equal(0, CostUtility.GetFakeMemoryAccess(new TupleType(new List<IRType>()), 0));
+        Assert.Equal((UInt128)0, CostUtility.GetFakeMemoryAccess(DataTypes.Float32, 0));
+        Assert.Equal((UInt128)0, CostUtility.GetFakeMemoryAccess(new TupleType(new List<IRType>()), 0));
     }
 
     [Fact]
     public void TestGetMemoryAccess()
     {
-        Assert.Equal(0, CostUtility.GetMemoryAccess(DataTypes.Float32, DataTypes.Float32));
+        Assert.Equal((UInt128)0, CostUtility.GetMemoryAccess(DataTypes.Float32, DataTypes.Float32));
+    }
+
+    [Fact]
+    public void TestDoubleCostSumErrorCase()
+    {
+        // note when use double costs, somtime the value sum will got error.
+        var c = new Cost()
+        {
+            [CostFactorNames.MemoryLoad] = (UInt128)1651643172136040,
+            [CostFactorNames.MemoryStore] = (UInt128)953885239498522,
+            [CostFactorNames.CPUCycles] = (UInt128)13437180688291688,
+        };
+
+        var c2 = new Cost()
+        {
+            [CostFactorNames.CPUCycles] = UInt128.One,
+        };
+
+        Assert.Equal((UInt128)16042709099926251, (c2 + c).Score);
     }
 }

--- a/src/Nncase.Tests/Core/UnitTestCost.cs
+++ b/src/Nncase.Tests/Core/UnitTestCost.cs
@@ -98,7 +98,7 @@ public sealed class UnitTestCost
     [Fact]
     public void TestGetCPUCycles()
     {
-        Assert.Equal((UInt128)0, CostUtility.GetCPUCycles(DataTypes.Int32));
+        Assert.Equal((UInt128)1, CostUtility.GetCPUCycles(DataTypes.Int32));
         Assert.Equal((UInt128)0, CostUtility.GetCPUCycles(new TupleType(new List<IRType>())));
     }
 
@@ -112,7 +112,7 @@ public sealed class UnitTestCost
     [Fact]
     public void TestGetMemoryAccess()
     {
-        Assert.Equal((UInt128)0, CostUtility.GetMemoryAccess(DataTypes.Float32, DataTypes.Float32));
+        Assert.Equal((UInt128)8, CostUtility.GetMemoryAccess(DataTypes.Float32, DataTypes.Float32));
     }
 
     [Fact]


### PR DESCRIPTION
1. when using double as cost value type:
c0 = { [MemoryLoad, 1651643172136040] [MemoryStore, 953885239498522] [CPUCycles, 13437180688291688] }
c1 = { [CPUCycles, 1] }
the `c0` will equal `c1 + c0`