### PR TITLE
GNNE-1714:shutdown FoldPrePostReshapeSoftmax transform

### DIFF
--- a/src/Nncase.Compiler/Compiler.cs
+++ b/src/Nncase.Compiler/Compiler.cs
@@ -127,7 +127,6 @@ internal class Compiler : ICompiler
             p.Add<Passes.Rules.Neutral.FoldNopCast>();
             p.Add<Passes.Rules.Neutral.FoldNopReshape>();
             p.Add<Passes.Rules.Neutral.FoldNopSlice>();
-            p.Add<Passes.Rules.Neutral.FoldPrePostReshapeSoftmax>();
             p.Add<Passes.Rules.Neutral.FoldSqueezeUnsqueeze>();
             p.Add<Passes.Rules.Neutral.FoldUnsqueezeSqueeze>();
             p.Add<Passes.Rules.Neutral.FoldTwoTransposes>();


### PR DESCRIPTION
shutdown FoldPrePostReshapeSoftmax transform, the conditions are not strict enough, it will cause damage to other scenes.