### PR TITLE
GNNE-1714:Fix/search time egraph

### DIFF
--- a/src/Nncase.EGraph/Passes/EGraphExtractors/SatExtractor.cs
+++ b/src/Nncase.EGraph/Passes/EGraphExtractors/SatExtractor.cs
@@ -77,7 +77,7 @@ internal class SatExtractor : IExtractor
         }
 
         var solver = new CpSolver();
-        int max_time = 600;
+        int max_time = 120;
         if (System.Environment.GetEnvironmentVariable("SOLVE_MAX_TIME") is string s_solve_max_time)
         {
             try

--- a/src/Nncase.Passes/Rules/Neutral/AddRangeOfAndMarker.cs
+++ b/src/Nncase.Passes/Rules/Neutral/AddRangeOfAndMarker.cs
@@ -195,7 +195,7 @@ public partial class AddRangeOfAndMarker : RewriteRule<Pattern>
         {
             var outputNames = new List<string>();
             var getItem = IR.F.Tensors.GetItem(call, i);
-            outputNames.Add("LSTMOutput_" + call.Metadata.OutputNames?[i]);
+            outputNames.Add(call.Metadata.OutputNames?[i] ?? "LSTMOutput_" + i.ToString());
             outputs[i].Metadata.OutputNames = outputNames;
         }
 


### PR DESCRIPTION
1，Modify the naming rules of LSTM GetItem；
2，Modify egraph search time to prevent deadlock。