### PR TITLE
Fix Not Equal

### DIFF
--- a/src/Nncase.Passes/Rules/Neutral/CombineQuantize.cs
+++ b/src/Nncase.Passes/Rules/Neutral/CombineQuantize.cs
@@ -68,7 +68,7 @@ public sealed partial class CombineQuantizeConcat : RewriteRule<Pattern>
                             }
                             else
                             {
-                                if (user != tuple)
+                                if (!ReferenceEquals(user, tuple))
                                 {
                                     return null;
                                 }


### PR DESCRIPTION
1. replace != with !ReferenceEquals in CombineQuantizeConcat