### PR TITLE
[feat] Support load cpu module from external path

### DIFF
--- a/src/Native/include/nncase/runtime/interpreter.h
+++ b/src/Native/include/nncase/runtime/interpreter.h
@@ -49,7 +49,7 @@ class NNCASE_API options_dict {
     }
 
   private:
-    std::unordered_map<std::string_view, std::variant<scalar, std::string_view>>
+    std::unordered_map<std::string_view, std::variant<scalar, std::string>>
         values_;
 };
 

--- a/src/Native/src/runtime/cpu/loaders/elf/elf_loader.cpp
+++ b/src/Native/src/runtime/cpu/loaders/elf/elf_loader.cpp
@@ -100,10 +100,26 @@ void elf_loader::load(std::span<const std::byte> elf) {
     }
 }
 
+void elf_loader::load_from_file(std::string_view path) {
+    handle_ = dlopen(path.data(), RTLD_NOW);
+    if (!handle_) {
+        throw std::runtime_error("dlopen error:" + std::string(dlerror()));
+    }
+
+    entry_ = dlsym(handle_, "block_entry");
+    if (!entry_) {
+        throw std::runtime_error("dlsym error:" + std::string(dlerror()));
+    }
+}
+
 void *elf_loader::entry() const noexcept {
+    if (entry_) {
+        return entry_;
+    }
+
     if (ctx_.ehdr.e_type == ET_EXEC) {
         return image_ + ctx_.ehdr.e_entry;
     } else {
-        return entry_;
+        return nullptr;
     }
 }

--- a/src/Native/src/runtime/cpu/loaders/elf/elf_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/elf/elf_loader.h
@@ -16,6 +16,7 @@
 #include "elfload.h"
 #include <nncase/compiler_defs.h>
 #include <span>
+#include <string_view>
 
 BEGIN_NS_NNCASE_RUNTIME
 
@@ -25,6 +26,7 @@ class elf_loader {
     ~elf_loader();
 
     void load(std::span<const std::byte> pe);
+    void load_from_file(std::string_view path);
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/loaders/macho/macho_loader.cpp
+++ b/src/Native/src/runtime/cpu/loaders/macho/macho_loader.cpp
@@ -88,6 +88,18 @@ void macho_loader::load(std::span<const std::byte> macho) {
 #endif
 }
 
+void macho_loader::load_from_file(std::string_view path) {
+    mod_ = dlopen(path.data(), RTLD_NOW);
+    if (!mod_) {
+        throw std::runtime_error("dlopen error:" + std::string(dlerror()));
+    }
+
+    sym_ = dlsym(mod_, "block_entry");
+    if (!sym_) {
+        throw std::runtime_error("dlsym error:" + std::string(dlerror()));
+    }
+}
+
 void *macho_loader::entry() const noexcept {
 #if 0
     return NSAddressOfSymbol(reinterpret_cast<NSSymbol>(sym_));

--- a/src/Native/src/runtime/cpu/loaders/macho/macho_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/macho/macho_loader.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <nncase/compiler_defs.h>
 #include <span>
+#include <string_view>
 
 BEGIN_NS_NNCASE_RUNTIME
 
@@ -31,6 +32,7 @@ class macho_loader {
     ~macho_loader();
 
     void load(std::span<const std::byte> macho);
+    void load_from_file(std::string_view path);
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/loaders/pe/pe_loader.cpp
+++ b/src/Native/src/runtime/cpu/loaders/pe/pe_loader.cpp
@@ -134,6 +134,13 @@ void pe_loader::load(std::span<const std::byte> pe) {
 #endif
 }
 
+void pe_loader::load_from_file(std::string_view path) {
+    image_ = LoadLibraryA(path.data());
+    THROW_WIN32_IF_NOT(image_);
+    entry_ = (void *)GetProcAddress((HMODULE)image_, "block_entry");
+    THROW_WIN32_IF_NOT(entry_);
+}
+
 void *pe_loader::entry() const noexcept {
 #if 1
     return entry_;

--- a/src/Native/src/runtime/cpu/loaders/pe/pe_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/pe/pe_loader.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <nncase/compiler_defs.h>
 #include <span>
+#include <string_view>
 
 BEGIN_NS_NNCASE_RUNTIME
 
@@ -24,6 +25,7 @@ class pe_loader {
     ~pe_loader();
 
     void load(std::span<const std::byte> pe);
+    void load_from_file(std::string_view path);
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/runtime_function.cpp
+++ b/src/Native/src/runtime/cpu/runtime_function.cpp
@@ -84,10 +84,7 @@ result<void> cpu_runtime_function::initialize_core(
             }
             return ok();
         }));
-    auto text = module().text().subspan(context.header().entrypoint,
-                                        context.header().text_size);
-    loader_.load(text);
-    block_entry_ = (block_entry_t)loader_.entry();
+    try_set(block_entry_, module().block_entry());
 
     // Allocate input descs
     auto input_size = parameters_size();

--- a/src/Native/src/runtime/cpu/runtime_function.h
+++ b/src/Native/src/runtime/cpu/runtime_function.h
@@ -20,14 +20,6 @@
 #include <nncase/tensor.h>
 #include <vector>
 
-#if WIN32
-#include "loaders/pe/pe_loader.h"
-#elif defined(__APPLE__)
-#include "loaders/macho/macho_loader.h"
-#else
-#include "loaders/elf/elf_loader.h"
-#endif
-
 BEGIN_NS_NNCASE_RT_MODULE(cpu)
 
 class cpu_runtime_function final : public runtime_function {
@@ -58,14 +50,6 @@ class cpu_runtime_function final : public runtime_function {
                                         std::byte *output_data) noexcept;
 
   private:
-#if WIN32
-    pe_loader loader_;
-#elif defined(__APPLE__)
-    macho_loader loader_;
-#else
-    elf_loader loader_;
-#endif
-
     block_entry_t block_entry_;
     std::vector<host_buffer_t> local_datas_;
     host_buffer_t output_buffer_;


### PR DESCRIPTION
- [x] Support load cpu module from external path when interpreter.options.cpu_external_module_path is set
- [x] Add command line options `--cpu_external_module_path` to test_cli