### PR TITLE
Add APIs to get native handle of modules

### DIFF
--- a/python/nncase/native/ffi.cpp
+++ b/python/nncase/native/ffi.cpp
@@ -498,6 +498,12 @@ PYBIND11_MODULE(_nncase, m) {
              [](interpreter &interp, uint8_t enable_profiling) {
                  interp.enable_profiling(enable_profiling);
              })
+        .def("get_native_handle_by_module_kind",
+             [](interpreter &interp, std::string_view kind, uint32_t flags) {
+                 auto module =
+                     interp.find_module_by_kind(kind).unwrap_or_throw();
+                 return module->native_handle(flags).unwrap_or_throw();
+             })
         .def("run",
              [](interpreter &interp) { interp.run().unwrap_or_throw(); });
 

--- a/python/nncaseruntime/native/ffi.cpp
+++ b/python/nncaseruntime/native/ffi.cpp
@@ -120,6 +120,12 @@ PYBIND11_MODULE(_nncaseruntime, m) {
              [](interpreter &interp, uint8_t enable_profiling) {
                  interp.enable_profiling(enable_profiling);
              })
+        .def("get_native_handle_by_module_kind",
+             [](interpreter &interp, std::string_view kind, uint32_t flags) {
+                 auto module =
+                     interp.find_module_by_kind(kind).unwrap_or_throw();
+                 return module->native_handle(flags).unwrap_or_throw();
+             })
         .def("run",
              [](interpreter &interp) { interp.run().unwrap_or_throw(); });
 

--- a/src/Native/include/nncase/runtime/interpreter.h
+++ b/src/Native/include/nncase/runtime/interpreter.h
@@ -72,6 +72,8 @@ class NNCASE_API interpreter {
 
     options_dict &options() noexcept;
     result<runtime_module *> find_module_by_id(size_t index) noexcept;
+    result<runtime_module *>
+    find_module_by_kind(std::string_view kind) noexcept;
     result<size_t> find_id_by_module(runtime_module *module) noexcept;
 
     /* V1 APIs */

--- a/src/Native/include/nncase/runtime/runtime_module.h
+++ b/src/Native/include/nncase/runtime/runtime_module.h
@@ -19,6 +19,7 @@
 #include "runtime_section_context.h"
 #include "span_reader.h"
 #include "stream_reader.h"
+#include <cstdint>
 
 BEGIN_NS_NNCASE_RUNTIME
 
@@ -44,6 +45,7 @@ class NNCASE_API runtime_module {
     result<void> initialize(stream_reader &reader,
                             interpreter &interp) noexcept;
     const module_kind_t &kind() const noexcept;
+    virtual result<uintptr_t> native_handle(uint32_t flags) const noexcept;
 
     interpreter &interp() const noexcept { return *interp_; }
 

--- a/src/Native/src/runtime/cpu/loaders/elf/elf_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/elf/elf_loader.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 #include "elfload.h"
+#include <cstdint>
 #include <nncase/compiler_defs.h>
 #include <span>
 #include <string_view>
@@ -27,6 +28,7 @@ class elf_loader {
 
     void load(std::span<const std::byte> pe);
     void load_from_file(std::string_view path);
+    uintptr_t handle() const noexcept { return (uintptr_t)handle_; }
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/loaders/macho/macho_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/macho/macho_loader.h
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstdint>
 #include <nncase/compiler_defs.h>
 #include <span>
 #include <string_view>
@@ -33,6 +34,7 @@ class macho_loader {
 
     void load(std::span<const std::byte> macho);
     void load_from_file(std::string_view path);
+    uintptr_t handle() const noexcept { return (uintptr_t)mod_; }
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/loaders/pe/pe_loader.h
+++ b/src/Native/src/runtime/cpu/loaders/pe/pe_loader.h
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstdint>
 #include <nncase/compiler_defs.h>
 #include <span>
 #include <string_view>
@@ -26,6 +27,7 @@ class pe_loader {
 
     void load(std::span<const std::byte> pe);
     void load_from_file(std::string_view path);
+    uintptr_t handle() const noexcept { return (uintptr_t)image_; }
     void *entry() const noexcept;
 
   private:

--- a/src/Native/src/runtime/cpu/runtime_module.cpp
+++ b/src/Native/src/runtime/cpu/runtime_module.cpp
@@ -85,6 +85,12 @@ result<void> cpu_runtime_module::initialize_text(
     return ok();
 }
 
+result<uintptr_t>
+cpu_runtime_module::native_handle(uint32_t flags) const noexcept {
+    CHECK_WITH_ERR(flags == 0, std::errc::invalid_argument);
+    return ok(loader_.handle());
+}
+
 result<block_entry_t> cpu_runtime_module::block_entry() const noexcept {
     return ok((block_entry_t)loader_.entry());
 }

--- a/src/Native/src/runtime/cpu/runtime_module.h
+++ b/src/Native/src/runtime/cpu/runtime_module.h
@@ -36,6 +36,8 @@ class cpu_runtime_module : public runtime_module {
     cpu_runtime_module() noexcept;
     virtual ~cpu_runtime_module();
 
+    result<uintptr_t> native_handle(uint32_t flags) const noexcept override;
+
     uint64_t tdim() const noexcept { return tdim_; }
     uint64_t bdim() const noexcept { return bdim_; }
     uint64_t cdim() const noexcept { return cdim_; }

--- a/src/Native/src/runtime/interpreter.cpp
+++ b/src/Native/src/runtime/interpreter.cpp
@@ -12,7 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "nncase/runtime/model.h"
 #include <cassert>
+#include <cstring>
 #include <iostream>
 #include <nncase/runtime/char_array_stream.h>
 #include <nncase/runtime/dbg.h>
@@ -236,6 +238,20 @@ result<void> interpreter::run() noexcept {
 result<runtime_module *> interpreter::find_module_by_id(size_t index) noexcept {
     CHECK_WITH_ERR(index < modules_.size(), std::errc::result_out_of_range);
     return ok(modules_[index].get());
+}
+
+result<runtime_module *>
+interpreter::find_module_by_kind(std::string_view kind) noexcept {
+    auto it =
+        std::find_if(modules_.begin(), modules_.end(),
+                     [&kind](const std::unique_ptr<runtime_module> &p) {
+                         return std::strncmp(p->kind().data(), kind.data(),
+                                             MAX_MODULE_KIND_LENGTH) == 0;
+                     });
+    if (it == modules_.end()) {
+        return err(std::errc::result_out_of_range);
+    }
+    return ok(it->get());
 }
 
 result<size_t> interpreter::find_id_by_module(runtime_module *module) noexcept {

--- a/src/Native/src/runtime/runtime_module.cpp
+++ b/src/Native/src/runtime/runtime_module.cpp
@@ -121,6 +121,11 @@ const module_kind_t &runtime_module::kind() const noexcept {
     return header_.kind;
 }
 
+result<uintptr_t>
+runtime_module::native_handle([[maybe_unused]] uint32_t flags) const noexcept {
+    return err(std::errc::not_supported);
+}
+
 result<void> runtime_module::initialize(std::span<const std::byte> payload,
                                         interpreter &interp) noexcept {
     interp_ = &interp;


### PR DESCRIPTION
This pull request adds support for retrieving native handles from runtime modules by their kind, exposing this functionality to both the C++ and Python APIs. The main changes include new APIs for module lookup by kind, a virtual method for accessing native handles, and loader-specific implementations to return the underlying handle. This enables advanced integration scenarios where direct access to module internals is needed.

**API Extensions:**

* Added `find_module_by_kind` method to the `interpreter` class to allow lookup of modules by their kind string. [[1]](diffhunk://#diff-f9e32089a7bbcbf076e25c3ba7b572c1aec3da40ab7a5f70c5a5b310262a0ef3R75-R76) [[2]](diffhunk://#diff-bfb602a52bcc445d589bcb76e0153d94b3320dc95e3aadebf9865c5945b9307cR243-R256)
* Introduced a new virtual method `native_handle(uint32_t flags)` in `runtime_module` for retrieving a module's native handle, with a default implementation returning "not supported". [[1]](diffhunk://#diff-67b3bbd965e12f33368daadcfc670fc57041331fe42eac1b761db6c3fecb0144R48) [[2]](diffhunk://#diff-7959a8368ddf7359138a2cd5648401ed3177290cd573d9fd4dd1c4ae2c1306faR124-R128)

**Loader and Module Implementations:**

* Implemented `native_handle` in `cpu_runtime_module` to return the loader's handle, and added `handle()` methods to `elf_loader`, `pe_loader`, and `macho_loader` to expose the underlying OS handle. [[1]](diffhunk://#diff-0f9f5189a3e6407af60586f19bee49a2b8839c8f2e93eb1692d10405aa88d913R39-R40) [[2]](diffhunk://#diff-f17b68062f8aa56726ea7a64e61821ec6163de5aaae41efd499cbd3cbfa7c6f2R88-R93) [[3]](diffhunk://#diff-9f10b5bda97972d97ea283ad72d446d08f6c9ab047c71ea649c0d70a4cbd3a76R31) [[4]](diffhunk://#diff-c63682fc35e1af206e7912d2e4dba61a3c5f557a6b01ea9b76e11ad3031ef95bR30) [[5]](diffhunk://#diff-be74ff63861b0c25247cb793c81b52122a3ae4b2bb4d070ac50d74f76fc9c26dR37)

**Python Bindings:**

* Exposed the new `get_native_handle_by_module_kind` method in both `_nncase` and `_nncaseruntime` Python modules, allowing Python users to retrieve native handles by module kind. [[1]](diffhunk://#diff-e4de4e60f07876e4f28899a2802f42b0420e4f4861c0a1d8ba22158fccc97723R501-R506) [[2]](diffhunk://#diff-40a07a4385b0ac5398e4705cd8011b0ebccf34e6ba375ea4477ad1499c3b810dR123-R128)

**Other:**

* Added missing `#include <cstdint>` headers in loader files for portability and correctness. [[1]](diffhunk://#diff-9f10b5bda97972d97ea283ad72d446d08f6c9ab047c71ea649c0d70a4cbd3a76R17) [[2]](diffhunk://#diff-c63682fc35e1af206e7912d2e4dba61a3c5f557a6b01ea9b76e11ad3031ef95bR16) [[3]](diffhunk://#diff-be74ff63861b0c25247cb793c81b52122a3ae4b2bb4d070ac50d74f76fc9c26dR16) [[4]](diffhunk://#diff-67b3bbd965e12f33368daadcfc670fc57041331fe42eac1b761db6c3fecb0144R22)